### PR TITLE
Align font size/weight across different sections in JSON schema UI

### DIFF
--- a/documentation/docs/pem-configuration.md
+++ b/documentation/docs/pem-configuration.md
@@ -53,7 +53,7 @@ select.form-control:hover {
 }
 
 .control-label {
-  font-weight: 500;
+  font-weight: 700;
 }
 
 .field-description {
@@ -61,7 +61,6 @@ select.form-control:hover {
 }
 
 legend {
-  font-size: 20px;
   font-weight: 700;
 }
 


### PR DESCRIPTION
As pointed out by @hflesche, the current font size/weight is not logical wrt. schema structure.

This PR aligns font size/weight across different parts, such that we rely on indentation only for differentiating different sections.


![image](https://github.com/user-attachments/assets/2b8fe3c1-b260-4f0c-9963-d97fe59449ff)
