### PR TITLE
Remove key-label logic + remove unicode characters

### DIFF
--- a/documentation/docs/pem-configuration.md
+++ b/documentation/docs/pem-configuration.md
@@ -74,35 +74,44 @@ legend {
   position: relative;
   top: 1px;
   display: inline-block;
-  font-family: "Glyphicons Halflings";
   font-style: normal;
-  font-weight: normal;
   line-height: 1;
+  font-size: 13px;
+  font-weight: 600;
 }
 
 .glyphicon-plus:before {
-  content: "➕";
+  content: "Add new";
   padding: 5px;
   border-radius: 5px;
-  background-color: oklch(92.5% 0.084 155.995)
-}
-
-.dark .glyphicon-plus:before {
-  background-color: oklch(39.3% 0.095 152.535)
+  color: oklch(53.2% 0.157 131.589);
+  background-color: oklch(96.7% 0.067 122.328);
+  border: 1px solid oklch(89.7% 0.196 126.665);
 }
 
 .glyphicon-remove:before {
-  content: "🗑️";
+  content: "Delete";
   padding: 5px;
   border-radius: 5px;
+  color: oklch(44.4% 0.177 26.899);
   background-color: oklch(93.6% 0.032 17.717);
   border: 1px solid oklch(88.5% 0.062 18.334);
 }
 .glyphicon-arrow-up:before {
-  content: "🢁";
+  content: "Move up";
+  padding: 5px;
+  border-radius: 5px;
+  color: oklch(68.1% 0.162 75.834);
+  background-color: oklch(97.3% 0.071 103.193);
+  border: 1px solid oklch(94.5% 0.129 101.54);
 }
 .glyphicon-arrow-down:before {
-  content: "🢃";
+  content: "Move down";
+  padding: 5px;
+  border-radius: 5px;
+  color: oklch(68.1% 0.162 75.834);
+  background-color: oklch(97.3% 0.071 103.193);
+  border: 1px solid oklch(94.5% 0.129 101.54);
 }
 
 .checkbox > label {

--- a/documentation/docs/yaml-edit/YamlEdit.tsx
+++ b/documentation/docs/yaml-edit/YamlEdit.tsx
@@ -18,33 +18,11 @@ import { copy } from "@equinor/eds-icons";
 
 import { TranslatableString, englishStringTranslator, replaceStringParameters } from '@rjsf/utils';
 
-// Workaround since the signature of translateString from rjsf does not provide us information about where we are in the schema
-const whereAreWeInSchema = {
-  inMineralSection: false,
-  inDiffCalculationSection: false,
-} 
-function domainSpecificStrings(stringToTranslate: TranslatableString, params?: string[]): string {
-  if(stringToTranslate === TranslatableString.KeyLabel && params && params.length > 0 && params[0].length > 0) {
-    if(params[0] === "PemConfig"){ // Reset the state when we are in the top level of schema
-      whereAreWeInSchema.inMineralSection = false;
-      whereAreWeInSchema.inDiffCalculationSection = false;
-    } else if(params[0] === "Minerals") {
-      whereAreWeInSchema.inMineralSection = true; // We are in the mineral section
-    } else if(params[0] === "VolumeFractions") {
-      whereAreWeInSchema.inMineralSection = false; // We are finished with the mineral section
-    } else if(params[0] === "Diff Calculation") {
-      whereAreWeInSchema.inDiffCalculationSection = true; // We are in the diff calculation section
-    }
-
-    if(whereAreWeInSchema.inMineralSection){
-      return replaceStringParameters('Mineral:', params);
-    }
-    if(whereAreWeInSchema.inDiffCalculationSection){
-      return replaceStringParameters('Parameter:', params);
-    }
+function customStrings(stringToTranslate: TranslatableString, params?: string[]): string {
+  if(stringToTranslate === TranslatableString.KeyLabel) {
+    return replaceStringParameters('Key:', params);
   }
-  
-  return englishStringTranslator(stringToTranslate, params); // Fallback to the default english
+  return englishStringTranslator(stringToTranslate, params);
 }
 
 export const YamlEdit = () => {
@@ -168,7 +146,7 @@ export const YamlEdit = () => {
               },
             }}
             showErrorList={false}
-            translateString={domainSpecificStrings}
+            translateString={customStrings}
           />
         </div>
       </div>


### PR DESCRIPTION
- Key label logic workaround unstable (different behavior observed depending on if loaded from YAML or not). Sticking with only `Key:` for now (at least less confusing than the default `($actual key) Key`, like e.g. `shale Key:`. 
- Unicode characters not installed on RHEL8 - remove. Use text only:


![image](https://github.com/user-attachments/assets/8deb9470-ced6-4d1c-86c5-8c1393996210)
