### PR TITLE
Avoid user interface jumping between rock physics models

### DIFF
--- a/documentation/docs/pem-configuration.md
+++ b/documentation/docs/pem-configuration.md
@@ -139,4 +139,12 @@ li.text-danger::marker {
   content: "⚠";
 }
 
+/* In order to avoid confusion we hide the duplicate model name attribution in auto-generated user interface */
+label[for="root_rock_matrix_model_model_name"], #root_rock_matrix_model_model_name, #root_rock_matrix_model_model_name__description, #root_rock_matrix_model_model_name__error,
+label[for="root_rock_matrix_model_parameters_sandstone_mode"], #root_rock_matrix_model_parameters_sandstone_mode, #root_rock_matrix_model_parameters_sandstone_mode__description, #root_rock_matrix_model_parameters_sandstone_mode__error {
+  display: none;
+}
+
+
+
 </style>

--- a/documentation/docs/pem-configuration.md
+++ b/documentation/docs/pem-configuration.md
@@ -139,7 +139,7 @@ li.text-danger::marker {
   content: "⚠";
 }
 
-/* In order to avoid confusion we hide the duplicate model name attribution in auto-generated user interface */
+/* In order to avoid confusion we hide duplicate name fields in auto-generated user interface */
 label[for="root_rock_matrix_model_model_name"], #root_rock_matrix_model_model_name, #root_rock_matrix_model_model_name__description, #root_rock_matrix_model_model_name__error,
 label[for="root_rock_matrix_model_parameters_sandstone_mode"], #root_rock_matrix_model_parameters_sandstone_mode, #root_rock_matrix_model_parameters_sandstone_mode__description, #root_rock_matrix_model_parameters_sandstone_mode__error {
   display: none;

--- a/src/fmu/pem/pem_utilities/rpm_models.py
+++ b/src/fmu/pem/pem_utilities/rpm_models.py
@@ -144,7 +144,7 @@ class VpVsRegressionParams(RhoRegressionMixin):
         description="List of float values for polynomial regression for Vs "
         "based on porosity",
     )
-    mode: SkipJsonSchema[Literal["vp_vs"]] = Field(
+    mode: Literal["vp_vs"] = Field(
         default="vp_vs",
         description="Regression mode mode must be set to 'vp_vs' for "
         "estimation of Vp and Vs based on porosity",
@@ -162,7 +162,7 @@ class KMuRegressionParams(RhoRegressionMixin):
         description="List of float values for polynomial regression for shear modulus "
         "based on porosity",
     )
-    mode: SkipJsonSchema[Literal["k_mu"]] = Field(
+    mode: Literal["k_mu"] = Field(
         default="k_mu",
         description="Regression mode mode must be set to 'k_mu' for "
         "estimation of bulk and shear modulus based on porosity",
@@ -180,7 +180,7 @@ class RegressionModels(BaseModel):
 
 class PatchyCementRPM(BaseModel):
     model_config = ConfigDict(title="Patchy Cement Model")
-    model: SkipJsonSchema[Literal[RPMType.PATCHY_CEMENT]]
+    model: Literal[RPMType.PATCHY_CEMENT]
     parameters: PatchyCementParams
 
 
@@ -192,11 +192,11 @@ class FriableRPM(BaseModel):
 
 class TMatrixRPM(BaseModel):
     model_config = ConfigDict(title="T-Matrix Inclusion Model")
-    model: SkipJsonSchema[Literal[RPMType.T_MATRIX]]
+    model: Literal[RPMType.T_MATRIX]
     parameters: TMatrixParams
 
 
 class RegressionRPM(BaseModel):
     model_config = ConfigDict(title="Regression Model")
-    model: SkipJsonSchema[Literal[RPMType.REGRESSION]]
+    model: Literal[RPMType.REGRESSION]
     parameters: RegressionModels

--- a/src/fmu/pem/pem_utilities/rpm_models.py
+++ b/src/fmu/pem/pem_utilities/rpm_models.py
@@ -180,23 +180,24 @@ class RegressionModels(BaseModel):
 
 class PatchyCementRPM(BaseModel):
     model_config = ConfigDict(title="Patchy Cement Model")
-    model: Literal[RPMType.PATCHY_CEMENT]
+    model_name: Literal[RPMType.PATCHY_CEMENT]
     parameters: PatchyCementParams
 
 
 class FriableRPM(BaseModel):
     model_config = ConfigDict(title="Friable Sand Model")
-    model: SkipJsonSchema[Literal[RPMType.FRIABLE]]
+    model_name: Literal[RPMType.FRIABLE]
     parameters: PatchyCementParams
 
 
 class TMatrixRPM(BaseModel):
     model_config = ConfigDict(title="T-Matrix Inclusion Model")
-    model: Literal[RPMType.T_MATRIX]
+    model_name: Literal[RPMType.T_MATRIX]
     parameters: TMatrixParams
 
 
 class RegressionRPM(BaseModel):
     model_config = ConfigDict(title="Regression Model")
-    model: Literal[RPMType.REGRESSION]
+    model_name: Literal[RPMType.REGRESSION]
     parameters: RegressionModels
+

--- a/tests/data/sim2seis/model/pem_config_condensate.yml
+++ b/tests/data/sim2seis/model/pem_config_condensate.yml
@@ -12,7 +12,7 @@ paths:
 # Dry rock parameters. It varies from model to model which of the parameters that are used.
 rock_matrix:
   model:
-    model: t_matrix  # One of patchy_cement, friable, t_matrix or regression
+    model_name: t_matrix  # One of patchy_cement, friable, t_matrix or regression
     parameters:
       t_mat_model_version: PETEC  # One of 'PETEC' or 'EXP'
       angle: 90.0

--- a/tests/data/sim2seis/model/pem_config_no_condensate.yml
+++ b/tests/data/sim2seis/model/pem_config_no_condensate.yml
@@ -12,7 +12,7 @@ paths:
 # Dry rock parameters. It varies from model to model which of the parameters that are used.
 rock_matrix:
   model:
-    model: t_matrix  # One of patchy_cement, friable, t_matrix or regression
+    model_name: t_matrix  # One of patchy_cement, friable, t_matrix or regression
     parameters:
       t_mat_model_version: PETEC  # One of 'PETEC' or 'EXP'
       angle: 90.0

--- a/tests/test_dry_rock.py
+++ b/tests/test_dry_rock.py
@@ -13,7 +13,7 @@ def test_dryrock_missing_rpm_model():
     """Test RockMatrixProperties instantiation with minimal valid data."""
     valid_data = {
         "model": {
-            "model": None,
+            "model_name": None,
             "parameters": {
                 "upper_bound_cement_fraction": 0.1,
                 "cement_fraction": 0.04,


### PR DESCRIPTION
Closes first bullet point in #31.

With current main, the generated interface jumps between different rock physics models. This appears to be due to that `model` choice (e.g. patchy cement, T-matrix, regression) is not part of the JSON schema, and therefore also not stored in the generated output config/Yaml. The output instead consists of this:
```yaml
# This YAML file is not complete/valid

rock_matrix:
  model:
    # model: patchy_cement <-- this is missing in the generated output
    parameters:
      upper_bound_cement_fraction: 0.1
      cement_fraction: 0.04
      critical_porosity: 0.4
      shear_reduction: 0.5
  minerals:
    shale:
      bulk_modulus: 25000000000
      shear_modulus: 12000000000
      density: 2680
...
```

When including choice of model in JSON schema, the user choice is respected, but we see it appear twice:
<img width="677" height="558" alt="image" src="https://github.com/user-attachments/assets/b865ed57-7c9c-4eeb-b247-136fe7ced35a" />

Adding specific style instructions to hide selected fields.
