### PR TITLE
Fix README and revert to GitHub markdown syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-# [!WARNING]
-
+> [!WARNING]
 > `fmu-pem` is not yet qualified technology, and as of today only applicable for
     selected pilot test fields.
 


### PR DESCRIPTION
After #67 the top section in readme was broken.