### PR TITLE
Avoid pressure sensitivity jump in UI

### DIFF
--- a/src/fmu/pem/pem_utilities/rpm_models.py
+++ b/src/fmu/pem/pem_utilities/rpm_models.py
@@ -58,7 +58,9 @@ class FriableParams(BaseModel):
 
     model_config = ConfigDict(title="Friable Model Parameters")
 
-    critical_porosity: float = Field(ge=0.3, le=0.5, default=0.4, description="Critical porosity")
+    critical_porosity: float = Field(
+        ge=0.3, le=0.5, default=0.4, description="Critical porosity"
+    )
     coordination_number_function: str = Field(
         default="PorBased", description="Coordination number function"
     )


### PR DESCRIPTION
After testing various setups, it looks like the "JSON schema ➡️ UI"-library does not like union of classes where none of them are valid initially (i.e. given default values). One potential fix is to add default value for the attribute that currently does not have this. The critical porosity bounds are currently `0.3` and `0.5`, i.e. one default value that perhaps can be considered is the middle point `0.4`? 

If default value can be added, this PR closes #69.