### PR TITLE
docs: remove arning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-> [!WARNING]
-> `fmu-pem` is not yet qualified technology, and as of today only applicable for
-    selected pilot test fields.
-
 **[📚 User documentation](https://equinor.github.io/fmu-pem/)**
 
 ## What is fmu-pem?


### PR DESCRIPTION
TRL4 is passed, so the warning about unqualifies technology is removed.