### PR TITLE
refactor: update after rock_physics import swapping is removed

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -120,8 +120,6 @@ are validated via `read_pem_config` in `import_config.py`.
   known.
 - Test files are named `test_<module>.py`. Keep tests focused on a single
   behaviour per function.
-- Tests that require the internal Equinor `rock-physics` package must be
-  guarded with `if INTERNAL_EQUINOR`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@ prior to running the PEM. Fluid and mineral properties can be found in the RokDo
 project, or from LFP logs, if they are available.
 
 > [!NOTE]
-> The fluid models contained in this module may not cover all possible cases. Gas
-condensate, very heavy oil, > or reservoir pressure under hydrocarbon bubble point will
-need additional proprietary code to run.
+> The fluid models contained in this module may not cover all possible cases.
+> Gas condensate, very heavy oil, or reservoir pressure under hydrocarbon bubble point
+> will need additional proprietary code to run.
 >
 > Equinor users can install additional proprietary models using
-
+>
 > ```bash
-> pip install "git+ssh://git@github.com/equinor/rock-physics"`
+> pip install "git+https://github.com/equinor/rock-physics@v2.0.0"`
 > ```
 
 ## How to develop fmu-pem?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "fmu-config",
     "fmu-dataio",
     "fmu-datamodels",
-    "rock-physics-open >= 0.6.0",
+    "rock-physics-open >= 1.0.0",
     "PyYAML >=6.0.1",
     "pydantic",
     "ert >= 14.1.10",

--- a/scripts/brie_test.ipynb
+++ b/scripts/brie_test.ipynb
@@ -10,11 +10,7 @@
     "# ruff: noqa: E501\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
-    "from rock_physics_open.equinor_utilities.std_functions import brie, wood\n",
-    "\n",
-    "from fmu.pem import INTERNAL_EQUINOR\n",
-    "\n",
-    "assert not INTERNAL_EQUINOR, \"This example expects rock_physics to not be installed.\""
+    "from rock_physics_open.equinor_utilities.std_functions import brie, wood"
    ]
   },
   {

--- a/scripts/brine_properties.ipynb
+++ b/scripts/brine_properties.ipynb
@@ -10,11 +10,13 @@
     "# ruff: noqa: E501\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
-    "from rock_physics_open.fluid_models.brine_model import brine_properties\n",
     "\n",
-    "from fmu.pem import INTERNAL_EQUINOR\n",
+    "from fmu.pem.pem_utilities.rock_physics_adapter import (\n",
+    "    HAS_PROPRIETARY_ROCK_PHYSICS,\n",
+    "    brine_properties,\n",
+    ")\n",
     "\n",
-    "assert not INTERNAL_EQUINOR, \"This example expects rock_physics to NOT be installed.\""
+    "assert not HAS_PROPRIETARY_ROCK_PHYSICS, \"Expected rock_physics to NOT be installed.\""
    ]
   },
   {

--- a/scripts/co2_properties.ipynb
+++ b/scripts/co2_properties.ipynb
@@ -10,11 +10,13 @@
     "# ruff: noqa: E501\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
-    "from rock_physics_open.span_wagner import co2_properties\n",
     "\n",
-    "from fmu.pem import INTERNAL_EQUINOR\n",
+    "from fmu.pem.pem_utilities.rock_physics_adapter import (\n",
+    "    HAS_PROPRIETARY_ROCK_PHYSICS,\n",
+    "    co2_properties,\n",
+    ")\n",
     "\n",
-    "assert not INTERNAL_EQUINOR, \"This example expects rock_physics to not be installed.\""
+    "assert not HAS_PROPRIETARY_ROCK_PHYSICS, \"Expected rock_physics to NOT be installed.\""
    ]
   },
   {

--- a/scripts/eff_min_props.ipynb
+++ b/scripts/eff_min_props.ipynb
@@ -16,11 +16,7 @@
     "    reuss,\n",
     "    voigt,\n",
     "    voigt_reuss_hill,\n",
-    ")\n",
-    "\n",
-    "from fmu.pem import INTERNAL_EQUINOR\n",
-    "\n",
-    "assert not INTERNAL_EQUINOR, \"This example expects rock_physics to not be installed.\""
+    ")"
    ]
   },
   {

--- a/scripts/gas_properties.ipynb
+++ b/scripts/gas_properties.ipynb
@@ -10,11 +10,13 @@
     "# ruff: noqa: E501\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
-    "from rock_physics_open.fluid_models.gas_model import gas_properties\n",
     "\n",
-    "from fmu.pem import INTERNAL_EQUINOR\n",
+    "from fmu.pem.pem_utilities.rock_physics_adapter import (\n",
+    "    HAS_PROPRIETARY_ROCK_PHYSICS,\n",
+    "    gas_properties,\n",
+    ")\n",
     "\n",
-    "assert not INTERNAL_EQUINOR, \"This example expects rock_physics to NOT be installed.\""
+    "assert not HAS_PROPRIETARY_ROCK_PHYSICS, \"Expected rock_physics to NOT be installed.\""
    ]
   },
   {

--- a/scripts/oil_properties.ipynb
+++ b/scripts/oil_properties.ipynb
@@ -10,11 +10,13 @@
     "# ruff: noqa: E501\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
-    "from rock_physics_open.fluid_models.oil_model import oil_properties\n",
     "\n",
-    "from fmu.pem import INTERNAL_EQUINOR\n",
+    "from fmu.pem.pem_utilities.rock_physics_adapter import (\n",
+    "    HAS_PROPRIETARY_ROCK_PHYSICS,\n",
+    "    oil_properties,\n",
+    ")\n",
     "\n",
-    "assert not INTERNAL_EQUINOR, \"This example expects rock_physics to not be installed.\""
+    "assert not HAS_PROPRIETARY_ROCK_PHYSICS, \"Expected rock_physics to NOT be installed.\""
    ]
   },
   {

--- a/src/fmu/pem/__init__.py
+++ b/src/fmu/pem/__init__.py
@@ -1,21 +1,7 @@
-"""
-The INTERNAL_EQUINOR property means that fmu-pem is run within the Equinor organisation
-where there is access to more elaborate fluid models and other rock physics
-models.
-"""
-
-try:  # noqa: SIM105
-    import init_rock_physics
-except (ImportError, ModuleNotFoundError):
-    INTERNAL_EQUINOR = False
-else:
-    INTERNAL_EQUINOR = True
-
 from .__main__ import main as pem
 from .run_pem import pem_fcn
 
 __all__ = [
     "pem_fcn",
     "pem",
-    "INTERNAL_EQUINOR",
 ]

--- a/src/fmu/pem/pem_functions/fluid_properties.py
+++ b/src/fmu/pem/pem_functions/fluid_properties.py
@@ -5,12 +5,8 @@ from math import isclose
 from typing import TYPE_CHECKING
 
 import numpy as np
-from rock_physics_open import fluid_models as flag
-from rock_physics_open import span_wagner
 from rock_physics_open.equinor_utilities.std_functions import brie, multi_wood
-from rock_physics_open.fluid_models.oil_model.oil_bubble_point import bp_standing
 
-from fmu.pem import INTERNAL_EQUINOR
 from fmu.pem.pem_utilities import (
     EffectiveFluidProperties,
     Fluids,
@@ -21,14 +17,20 @@ from fmu.pem.pem_utilities.fipnum_pvtnum_utilities import (
     input_num_string_to_list,
     validate_zone_coverage,
 )
+from fmu.pem.pem_utilities.rock_physics_adapter import (
+    HAS_PROPRIETARY_ROCK_PHYSICS,
+    bp_standing,
+    brine_properties,
+    co2_properties,
+    condensate_properties,
+    gas_properties,
+    oil_properties,
+    saturations_below_bubble_point,
+)
 
 if TYPE_CHECKING:
     from fmu.pem.pem_utilities.pem_config_validation import PVTZone
 
-if INTERNAL_EQUINOR:
-    from rock_physics_open.fluid_models import (
-        saturations_below_bubble_point,  # noqa: F821
-    )
 
 # Hard-code the default tolerance limit for fraction of cells below bubble point
 BUBBLE_POINT_FRACTION_TOLERANCE = 0.01
@@ -67,61 +69,50 @@ def _adjust_bubble_point(
     to be taken into account
 
     If below bubble point: evolve saturations, GOR and free gas gravity."""
-    try:
-        bp = bp_standing(
-            density=oil_density_ref,
-            gas_oil_ratio=gor,
-            gas_gravity=oil_gas_gravity,
-            temperature=temp,
-        )
-        # Only consider cells where the oil saturation is positive
-        idx_below = np.logical_and(pres <= bp, so > 0.0)
-        if np.any(idx_below):
-            # More than 1% of cells below bubble point will be regarded as an error
-            # situation if the gas Z-factor is set to default value of 1.0. If the
-            # user modifies the Z-factor, we regard cells below bubble point to be
-            # an expected situation and not an error.
-            frac_below = np.sum(idx_below) / pres.size
-            if frac_below > BUBBLE_POINT_FRACTION_TOLERANCE and isclose(
-                zone.gas_z_factor, 1.0
-            ):
-                raise ValueError(
-                    f"Fraction of cells with pressure below oil bubble point is "
-                    f"{frac_below:.3f}. "
-                    "If you experience this, please raise an issue in "
-                    "https://github.com/equinor/fmu-pem/issues. "
-                    "If this is an expected situation, add a "
-                    "gas Z-factor (deviation from an ideal gas) to the YAML parameter "
-                    "file for each PVTNUM zone, e.g.: 'gas_z_factor: 0.97' "
-                    "The gas Z-factor must deviate from 1.0."
-                )
-            warnings.warn(
-                f"Detected pressure below bubble point for oil in {np.sum(idx_below)} "
-                f"cells, this is {frac_below:.3f} of total number of cells."
-            )
-    except NotImplementedError:
-        warnings.warn("Bubble point function unavailable; assuming above bubble point.")
-        idx_below = np.zeros_like(pres, dtype=bool)
-
+    bp = bp_standing(
+        density=oil_density_ref,
+        gas_oil_ratio=gor,
+        gas_gravity=oil_gas_gravity,
+        temperature=temp,
+    )
+    # Only consider cells where the oil saturation is positive
+    idx_below = np.logical_and(pres <= bp, so > 0.0)
     if np.any(idx_below):
-        try:
-            sg, so, gor, free_gas_gravity = saturations_below_bubble_point(
-                gas_saturation_init=sg,
-                oil_saturation_init=so,
-                brine_saturation_init=sw,
-                gor_init=gor,
-                oil_gas_gravity=oil_gas_gravity,
-                free_gas_gravity=free_gas_gravity,
-                oil_density=oil_density_ref,
-                z_factor=zone.gas_z_factor,
-                pres_depl=pres,
-                temp_res=temp,
+        # More than 1% of cells below bubble point will be regarded as an error
+        # situation if the gas Z-factor is set to default value of 1.0. If the
+        # user modifies the Z-factor, we regard cells below bubble point to be
+        # an expected situation and not an error.
+        frac_below = np.sum(idx_below) / pres.size
+        if frac_below > BUBBLE_POINT_FRACTION_TOLERANCE and isclose(
+            zone.gas_z_factor, 1.0
+        ):
+            raise ValueError(
+                f"Fraction of cells with pressure below oil bubble point is "
+                f"{frac_below:.3f}. "
+                "If you experience this, please raise an issue in "
+                "https://github.com/equinor/fmu-pem/issues. "
+                "If this is an expected situation, add a "
+                "gas Z-factor (deviation from an ideal gas) to the YAML parameter "
+                "file for each PVTNUM zone, e.g.: 'gas_z_factor: 0.97' "
+                "The gas Z-factor must deviate from 1.0."
             )
-        except (NameError, ModuleNotFoundError, NotImplementedError):
-            warnings.warn(
-                "Estimation of oil properties below bubble point requires proprietary "
-                "model. Estimation of oil properties below bubble point are uncertain."
-            )
+        warnings.warn(
+            f"Detected pressure below bubble point for oil in {np.sum(idx_below)} "
+            f"cells, this is {frac_below:.3f} of total number of cells."
+        )
+
+        sg, so, gor, free_gas_gravity = saturations_below_bubble_point(
+            gas_saturation_init=sg,
+            oil_saturation_init=so,
+            brine_saturation_init=sw,
+            gor_init=gor,
+            oil_gas_gravity=oil_gas_gravity,
+            free_gas_gravity=free_gas_gravity,
+            oil_density=oil_density_ref,
+            z_factor=zone.gas_z_factor,
+            pres_depl=pres,
+            temp_res=temp,
+        )
     return sw, sg, so, gor, free_gas_gravity, idx_below
 
 
@@ -131,11 +122,11 @@ def _brine_props(
     salinity: np.ndarray,
     zone: PVTZone,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """Estimate brine properties by FLAG or Batzle & Wang model."""
+    """Estimate brine properties."""
     p_na = np.array(zone.brine.perc_na)
     p_ca = np.array(zone.brine.perc_ca)
     p_k = np.array(zone.brine.perc_k)
-    vp, rho, bulk = flag.brine_properties(
+    vp, rho, bulk = brine_properties(
         temperature=temp,
         pressure=pres,
         salinity=salinity,
@@ -153,13 +144,13 @@ def _oil_props(
     oil_density_ref: np.ndarray,
     oil_gas_gravity: np.ndarray,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """Estimate oil properties by FLAG or Batzle & Wang model."""
-    vp, rho, bulk = flag.oil_properties(
+    """Estimate oil properties."""
+    vp, rho, bulk = oil_properties(
         temperature=temp,
         pressure=pres,
-        gas_gravity=oil_gas_gravity,
         rho0=oil_density_ref,
         gas_oil_ratio=gor,
+        gas_gravity=oil_gas_gravity,
     )
     return rho, bulk, vp
 
@@ -170,26 +161,20 @@ def _gas_or_co2_props(
     gas_gravity: np.ndarray,
     zone: PVTZone,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """Estimate gas properties by FLAG or Batzle & Wang and co2 properties by
-    FLAG or Span & Wagner model."""
+    """Estimate gas properties or co2 properties."""
     if zone.gas_saturation_is_co2:
-        if zone.co2_model == CO2Models.FLAG and INTERNAL_EQUINOR:
-            vp, rho, bulk = flag.co2_properties(  # noqa: F821
-                temp=temp,
-                pres=pres,
-            )
-        else:
-            vp, rho, bulk = span_wagner.co2_properties(
-                temp=temp,
-                pres=pres,
-            )
+        vp, rho, bulk = co2_properties(
+            temperature=temp,
+            pressure=pres,
+            use_proprietary_model=zone.co2_model == CO2Models.FLAG,
+        )
     else:
-        vp, rho, bulk = flag.gas_properties(
+        vp, rho, bulk = gas_properties(
             temperature=temp,
             pressure=pres,
             gas_gravity=gas_gravity,
             model=zone.gas.model,
-        )[0:3]
+        )
     return rho, bulk, vp
 
 
@@ -213,31 +198,31 @@ def _apply_condensate_if_any(
     0.0. An RV of 0.0 means that the gas is dry, which is already calculated
     NB: condensate properties calculation requires proprietary model
     """
-    if not (zone.calculate_condensate and rv is not None and INTERNAL_EQUINOR):
+    if not zone.calculate_condensate:
+        return
+    if rv is None:
+        return
+    if not HAS_PROPRIETARY_ROCK_PHYSICS:
         return
     idx_dry = np.isclose(rv, 0.0, atol=1e-10)
     if np.all(idx_dry):
         return
+
     cond = zone.condensate
     cond_gor = 1.0 / rv[~idx_dry]
     cond_gr = cond.gas_gravity * np.ones_like(cond_gor)
     cond_rho0 = cond.reference_density * np.ones_like(cond_gor)
-    if rv is not None and temp is not None and pres is not None:
-        vp_c, rho_c, bulk_c = flag.condensate_properties(  # noqa: F821
-            temperature=temp[~idx_dry],
-            pressure=pres[~idx_dry],
-            rho0=cond_rho0,
-            gas_oil_ratio=cond_gor,
-            gas_gravity=cond_gr,
-        )
-        gas_rho[~idx_dry] = rho_c
-        gas_bulk[~idx_dry] = bulk_c
-        gas_vp[~idx_dry] = vp_c
-    else:
-        raise ValueError(
-            "Condensate properties calculation requires non-null `rv`, `temp`, and "
-            "`pres`."
-        )
+
+    vp_c, rho_c, bulk_c = condensate_properties(
+        temperature=temp[~idx_dry],
+        pressure=pres[~idx_dry],
+        rho0=cond_rho0,
+        gas_oil_ratio=cond_gor,
+        gas_gravity=cond_gr,
+    )
+    gas_rho[~idx_dry] = rho_c
+    gas_bulk[~idx_dry] = bulk_c
+    gas_vp[~idx_dry] = vp_c
 
 
 def _mix(
@@ -324,8 +309,8 @@ def effective_fluid_properties_zoned(
         ValueError: If PVT zone definitions overlap, have uncovered grid values, misuse
             wildcard '*', or condensate calculation is requested but `rv` is missing.
         NotImplementedError: If condensate modeling is requested without proprietary
-            implementation (`INTERNAL_EQUINOR` is False), or bubble point evolution
-            depends on an unavailable model.
+            implementation (`HAS_PROPRIETARY_ROCK_PHYSICS` is False), or bubble point
+            evolution depends on an unavailable model.
         RuntimeError: If array shape mismatches prevent assignment to result arrays.
         TypeError: If input types do not conform to expected models / masked arrays.
 

--- a/src/fmu/pem/pem_functions/run_t_matrix_model.py
+++ b/src/fmu/pem/pem_functions/run_t_matrix_model.py
@@ -178,7 +178,6 @@ def run_t_matrix_model(
             )
         if time_step > 0 and rock_matrix.pressure_sensitivity:
             vp, vs, rho, _, _ = carbonate_pressure_model(
-                tmp_fl_rho,
                 vp,
                 vs,
                 rho,

--- a/src/fmu/pem/pem_utilities/pem_config_validation.py
+++ b/src/fmu/pem/pem_utilities/pem_config_validation.py
@@ -16,7 +16,7 @@ from pydantic.json_schema import SkipJsonSchema
 from pydantic_core.core_schema import ValidationInfo
 
 from fmu.datamodels.fmu_results.global_configuration import GlobalConfiguration
-from fmu.pem import INTERNAL_EQUINOR
+from fmu.pem.pem_utilities.rock_physics_adapter import HAS_PROPRIETARY_ROCK_PHYSICS
 
 from .enum_defs import (
     CO2Models,
@@ -506,7 +506,7 @@ class PVTZone(BaseModel):
 
     @model_validator(mode="after")
     def check_fluid_type(self) -> Self:
-        if self.calculate_condensate and not INTERNAL_EQUINOR:
+        if self.calculate_condensate and not HAS_PROPRIETARY_ROCK_PHYSICS:
             raise NotImplementedError(
                 "Missing model for condensate, proprietary model required"
             )

--- a/src/fmu/pem/pem_utilities/rock_physics_adapter.py
+++ b/src/fmu/pem/pem_utilities/rock_physics_adapter.py
@@ -1,0 +1,277 @@
+import warnings
+
+import numpy as np
+from rock_physics_open.fluid_models import (
+    brine_properties as open_brine_properties,
+)
+from rock_physics_open.fluid_models import (
+    gas_properties as open_gas_properties,
+)
+from rock_physics_open.fluid_models import (
+    oil_properties as open_oil_properties,
+)
+from rock_physics_open.fluid_models.oil_model.oil_bubble_point import (
+    bp_standing as open_bp_standing,
+)
+from rock_physics_open.span_wagner import (
+    co2_properties as open_co2_properties,
+)
+
+from fmu.pem.pem_utilities.enum_defs import GasModels
+
+# This file acts as a compatibility layer (adapter) for proprietary rock physics models.
+# It uses the proprietary implementation when available, otherwise falls back to
+# open-source alternatives. Ensures consistent parameters, return types, units
+# and clear error handling across all rock physics operations.
+HAS_PROPRIETARY_ROCK_PHYSICS: bool
+"""`True` if the proprietary rock_physics package is installed and importable
+with all required modules, `False` otherwise."""
+
+try:
+    from rock_physics.fluid_models import (  # type: ignore[import]
+        brine_properties as internal_brine_properties,
+    )
+    from rock_physics.fluid_models import (  # type: ignore[import]
+        co2_properties as internal_co2_properties,
+    )
+    from rock_physics.fluid_models import (  # type: ignore[import]
+        condensate_properties as internal_condensate_properties,
+    )
+    from rock_physics.fluid_models import (  # type: ignore[import]
+        gas_properties as internal_gas_properties,
+    )
+    from rock_physics.fluid_models import (  # type: ignore[import]
+        oil_properties as internal_oil_properties,
+    )
+    from rock_physics.fluid_models import (  # type: ignore[import]
+        saturations_below_bubble_point as internal_saturations_below_bubble_point,
+    )
+    from rock_physics.fluid_models.oil_model.oil_bubble_point import (  # type: ignore[import]
+        bp_standing as internal_bp_standing,
+    )
+
+    HAS_PROPRIETARY_ROCK_PHYSICS = True
+except (ImportError, ModuleNotFoundError, NotImplementedError):
+    HAS_PROPRIETARY_ROCK_PHYSICS = False
+
+
+def bp_standing(
+    density: np.ndarray,
+    gas_oil_ratio: np.ndarray,
+    gas_gravity: np.ndarray,
+    temperature: np.ndarray,
+) -> np.ndarray:
+    """Calculate bubble point pressure with proprietary model when available.
+
+    Otherwise, uses open-source model.
+    """
+    if HAS_PROPRIETARY_ROCK_PHYSICS:
+        bp = internal_bp_standing(
+            density=density,
+            gas_oil_ratio=gas_oil_ratio,
+            gas_gravity=gas_gravity,
+            temperature=temperature,
+        )
+    else:
+        bp = open_bp_standing(
+            density=density,
+            gas_oil_ratio=gas_oil_ratio,
+            gas_gravity=gas_gravity,
+            temperature=temperature,
+        )
+    return bp
+
+
+def brine_properties(
+    temperature: np.ndarray,
+    pressure: np.ndarray,
+    salinity: np.ndarray,
+    p_nacl: np.ndarray,
+    p_cacl: np.ndarray,
+    p_kcl: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Calculate brine properties with proprietary (FLAG) model when available.
+
+    Otherwise, uses open-source (Batzle & Wang) model.
+
+    `p_nacl`, `p_cacl`, `p_kcl` parameters are only used for the proprietary model.
+    """
+    if HAS_PROPRIETARY_ROCK_PHYSICS:
+        vp, rho, bulk = internal_brine_properties(
+            temperature=temperature,
+            pressure=pressure,
+            salinity=salinity,
+            p_nacl=p_nacl,
+            p_cacl=p_cacl,
+            p_kcl=p_kcl,
+        )
+    else:
+        vp, rho, bulk = open_brine_properties(
+            temperature=temperature,
+            pressure=pressure,
+            salinity=salinity,
+        )
+    return vp, rho, bulk
+
+
+def co2_properties(
+    temperature: np.ndarray,
+    pressure: np.ndarray,
+    use_proprietary_model: bool = True,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Calculate CO2 properties with proprietary (FLAG) model when available.
+
+    `use_proprietary_model` can be set to `False` to use open-source (Span & Wagner)
+    equivalent, even when the proprietary model is available.
+
+    Note that the Span&Wagner model is recommended, even if the FLAG model is available.
+    """
+    if use_proprietary_model and HAS_PROPRIETARY_ROCK_PHYSICS:
+        vp, rho, bulk = internal_co2_properties(
+            temperature=temperature,
+            pressure=pressure,
+        )
+    else:
+        vp, rho, bulk = open_co2_properties(
+            temp=temperature,
+            pres=pressure,
+        )
+    return vp, rho, bulk
+
+
+def condensate_properties(
+    temperature: np.ndarray,
+    pressure: np.ndarray,
+    rho0: np.ndarray,
+    gas_oil_ratio: np.ndarray,
+    gas_gravity: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Calculate condensate properties with proprietary model.
+
+    Raises error if the proprietary model is not available.
+    """
+    if not HAS_PROPRIETARY_ROCK_PHYSICS:
+        raise RuntimeError(
+            "Condensate property calculation is not possible without the proprietary "
+            "rock physics package installed."
+        )
+
+    vp_c, rho_c, bulk_c = internal_condensate_properties(
+        temperature=temperature,
+        pressure=pressure,
+        rho0=rho0,
+        gas_oil_ratio=gas_oil_ratio,
+        gas_gravity=gas_gravity,
+    )
+    return vp_c, rho_c, bulk_c
+
+
+def gas_properties(
+    temperature: np.ndarray,
+    pressure: np.ndarray,
+    gas_gravity: np.ndarray,
+    model: GasModels = GasModels.HC2016,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Calculate gas properties with proprietary (FLAG) model when available.
+
+    Otherwise, uses open-source (Batzle & Wang) model.
+
+    `model` parameter is only used for the proprietary model.
+    """
+    if HAS_PROPRIETARY_ROCK_PHYSICS:
+        vp, rho, bulk, _ = internal_gas_properties(
+            temperature=temperature,
+            pressure=pressure,
+            gas_gravity=gas_gravity,
+            model=model.value,
+        )
+    else:
+        vp, rho, bulk, _ = open_gas_properties(
+            temperature=temperature,
+            pressure=pressure,
+            gas_gravity=gas_gravity,
+        )
+    return vp, rho, bulk
+
+
+def oil_properties(
+    temperature: np.ndarray,
+    pressure: np.ndarray,
+    rho0: np.ndarray,
+    gas_oil_ratio: np.ndarray,
+    gas_gravity: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Calculate oil properties with proprietary (FLAG) model when available.
+
+    Otherwise, uses open-source (Han-Batzle) model.
+    """
+    if HAS_PROPRIETARY_ROCK_PHYSICS:
+        vp, rho, bulk = internal_oil_properties(
+            temperature=temperature,
+            pressure=pressure,
+            rho0=rho0,
+            gas_oil_ratio=gas_oil_ratio,
+            gas_gravity=gas_gravity,
+        )
+    else:
+        vp, rho, bulk = open_oil_properties(
+            temperature=temperature,
+            pressure=pressure,
+            rho0=rho0,
+            gas_oil_ratio=gas_oil_ratio,
+            gas_gravity=gas_gravity,
+            model_version="HB",
+        )
+    return vp, rho, bulk
+
+
+def saturations_below_bubble_point(
+    gas_saturation_init: np.ndarray,
+    oil_saturation_init: np.ndarray,
+    brine_saturation_init: np.ndarray,
+    gor_init: np.ndarray,
+    oil_gas_gravity: np.ndarray,
+    free_gas_gravity: np.ndarray,
+    oil_density: np.ndarray,
+    z_factor: float,
+    pres_depl: np.ndarray,
+    temp_res: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Calculate saturations below bubble point with proprietary model when available.
+
+    Otherwise, raises warning and returns input values back as output.
+    """
+    if HAS_PROPRIETARY_ROCK_PHYSICS:
+        (
+            gas_saturation_depleted,
+            oil_saturation_depleted,
+            gor_depleted,
+            gas_gravity_depleted,
+        ) = internal_saturations_below_bubble_point(
+            gas_saturation_init=gas_saturation_init,
+            oil_saturation_init=oil_saturation_init,
+            brine_saturation_init=brine_saturation_init,
+            gor_init=gor_init,
+            oil_gas_gravity=oil_gas_gravity,
+            free_gas_gravity=free_gas_gravity,
+            oil_density=oil_density,
+            z_factor=z_factor,
+            pres_depl=pres_depl,
+            temp_res=temp_res,
+        )
+    else:
+        warnings.warn(
+            "Estimation of oil properties below bubble point requires proprietary "
+            "model. Estimation of oil properties below bubble point is uncertain."
+        )
+        # return input values back as output (do nothing)
+        gas_saturation_depleted = gas_saturation_init
+        oil_saturation_depleted = oil_saturation_init
+        gor_depleted = gor_init
+        gas_gravity_depleted = free_gas_gravity
+    return (
+        gas_saturation_depleted,
+        oil_saturation_depleted,
+        gor_depleted,
+        gas_gravity_depleted,
+    )

--- a/tests/test_config_file_validation.py
+++ b/tests/test_config_file_validation.py
@@ -3,12 +3,12 @@ from pathlib import Path
 
 import pytest
 
-from fmu.pem import INTERNAL_EQUINOR
 from fmu.pem.pem_utilities.import_config import (
     find_key_first,
     get_global_params_and_dates,
     read_pem_config,
 )
+from fmu.pem.pem_utilities.rock_physics_adapter import HAS_PROPRIETARY_ROCK_PHYSICS
 
 
 def test_validate_new_pem_config_multizone(testdata, monkeypatch, data_dir):
@@ -19,7 +19,7 @@ def test_validate_new_pem_config_multizone(testdata, monkeypatch, data_dir):
     obs_date_prefix = "HIST"
     mod_date_prefix = "HIST"
     pem_config_file_name = Path("sim2seis/model/pem_config_condensate_multi.yml")
-    if INTERNAL_EQUINOR:
+    if HAS_PROPRIETARY_ROCK_PHYSICS:
         try:
             config = read_pem_config(pem_config_file_name)
             # Read necessary part of global configurations and parameters
@@ -44,7 +44,7 @@ def test_validate_new_pem_config_multizone_no_prefix(testdata, monkeypatch, data
     global_dir = "fmuconfig/output"
     global_file = "global_variables.yml"
     pem_config_file_name = Path("sim2seis/model/pem_config_condensate_multi.yml")
-    if INTERNAL_EQUINOR:
+    if HAS_PROPRIETARY_ROCK_PHYSICS:
         try:
             config = read_pem_config(pem_config_file_name)
             # Read necessary part of global configurations and parameters
@@ -64,7 +64,7 @@ def test_validate_new_pem_config_multizone_no_prefix(testdata, monkeypatch, data
 def test_validate_new_pem_config_condensate(testdata, monkeypatch, data_dir):
     monkeypatch.chdir(data_dir)
     pem_config_file_name = Path("sim2seis/model/pem_config_condensate.yml")
-    if INTERNAL_EQUINOR:
+    if HAS_PROPRIETARY_ROCK_PHYSICS:
         try:
             _ = read_pem_config(pem_config_file_name)
         except Exception as e:

--- a/tests/test_ert_hooks.py
+++ b/tests/test_ert_hooks.py
@@ -5,7 +5,7 @@ from math import isclose
 import pytest
 import xtgeo
 
-from fmu.pem import INTERNAL_EQUINOR
+from fmu.pem.pem_utilities.rock_physics_adapter import HAS_PROPRIETARY_ROCK_PHYSICS
 
 try:
     # pylint: disable=unused-import
@@ -42,7 +42,7 @@ def test_pem_through_ert(testdata, monkeypatch, data_dir):
     assert actnum.sum() == 71475
     assert (grid.actnum_array == actnum).all()
 
-    if INTERNAL_EQUINOR:
+    if HAS_PROPRIETARY_ROCK_PHYSICS:
         truth_values = {
             "eclipse--effective_pressure--20180101.roff": 360008292337.79907,
             "eclipse--formation_pressure--20180101.roff": 2204158466687.0117,

--- a/tests/test_ert_hooks_condensate.py
+++ b/tests/test_ert_hooks_condensate.py
@@ -5,7 +5,7 @@ from math import isclose
 import pytest
 import xtgeo
 
-from fmu.pem import INTERNAL_EQUINOR
+from fmu.pem.pem_utilities.rock_physics_adapter import HAS_PROPRIETARY_ROCK_PHYSICS
 
 try:
     # pylint: disable=unused-import
@@ -21,7 +21,7 @@ except ImportError:
     not HAVE_ERT, reason="ERT is not installed, skipping hook implementation tests."
 )
 def test_pem_through_ert(testdata, monkeypatch, data_dir):
-    if not INTERNAL_EQUINOR:
+    if not HAS_PROPRIETARY_ROCK_PHYSICS:
         pytest.skip("condensate model requires proprietary code, skipping test")
     monkeypatch.chdir(data_dir)
     pem_output_path = data_dir / "sim2seis/output/pem"

--- a/tests/test_fluids.py
+++ b/tests/test_fluids.py
@@ -1,11 +1,17 @@
+from typing import cast
+
 import numpy as np
 import pytest
 
-from fmu.pem import INTERNAL_EQUINOR
 from fmu.pem.pem_functions import fluid_properties
 from fmu.pem.pem_functions.fluid_properties import effective_fluid_properties_zoned
-from fmu.pem.pem_utilities import EffectiveFluidProperties, SimRstProperties
-from fmu.pem.pem_utilities.enum_defs import CO2Models, FluidMixModel, TemperatureMethod
+from fmu.pem.pem_utilities import EffectiveFluidProperties, Fluids, SimRstProperties
+from fmu.pem.pem_utilities.enum_defs import (
+    CO2Models,
+    FluidMixModel,
+    GasModels,
+    TemperatureMethod,
+)
 
 
 # Stubs for fluid parameters
@@ -22,7 +28,7 @@ class StubGasParams:
     """Stub gas params class"""
 
     gas_gravity = 0.65
-    model = "flag_default"
+    model = GasModels.HC2016
 
 
 class StubOilParams:
@@ -165,84 +171,6 @@ def sim_props_with_condensate():
     )
 
 
-@pytest.fixture(autouse=True)
-def mock_flag_models(monkeypatch):
-    def brine_properties(temperature, pressure, salinity, p_nacl, p_cacl, p_kcl):
-        n = len(temperature)
-        return np.full(n, 1500.0), np.full(n, 1030.0), np.full(n, 2.5e9)
-
-    def oil_properties(temperature, pressure, rho0, gas_oil_ratio, gas_gravity):
-        n = len(temperature)
-        return np.full(n, 1400.0), np.full(n, 800.0), np.full(n, 1.5e9)
-
-    def gas_properties(temperature, pressure, gas_gravity, model):
-        n = len(temperature)
-        return np.full(n, 2000.0), np.full(n, 200.0), np.full(n, 0.5e9), None
-
-    def co2_properties(temp, pres):
-        n = len(temp)
-        return np.full(n, 1800.0), np.full(n, 400.0), np.full(n, 0.8e9)
-
-    def bp_standing_mock(density, gas_oil_ratio, gas_gravity, temperature):
-        """
-        Mock bubble point calculation.
-        Returns 100 bar (1e7 Pa) - this is above sim_props_low_pressure (50 bar)
-        but below sim_props_high_pressure (500 bar) and sim_props_no_condensate
-        (200 bar).
-        """
-        n = len(density) if hasattr(density, "__len__") else 1
-        return np.full(n, 1.0e7)  # 100 bar in Pa
-
-    monkeypatch.setattr(fluid_properties.flag, "brine_properties", brine_properties)
-    monkeypatch.setattr(fluid_properties.flag, "oil_properties", oil_properties)
-    monkeypatch.setattr(fluid_properties.flag, "gas_properties", gas_properties)
-    monkeypatch.setattr(fluid_properties, "bp_standing", bp_standing_mock)
-
-    # CO2 properties available through different modules depending on INTERNAL_EQUINOR
-    if INTERNAL_EQUINOR:
-        monkeypatch.setattr(fluid_properties.flag, "co2_properties", co2_properties)
-    else:
-        monkeypatch.setattr(
-            fluid_properties.span_wagner, "co2_properties", co2_properties
-        )
-
-    if INTERNAL_EQUINOR:
-
-        def condensate_properties(
-            temperature, pressure, rho0, gas_oil_ratio, gas_gravity
-        ):
-            n = len(temperature)
-            return np.full(n, 1600.0), np.full(n, 600.0), np.full(n, 1.0e9)
-
-        monkeypatch.setattr(
-            fluid_properties.flag, "condensate_properties", condensate_properties
-        )
-
-    if INTERNAL_EQUINOR:
-
-        def saturations_below_bubble_point_mock(
-            gas_saturation_init,
-            oil_saturation_init,
-            brine_saturation_init,
-            gor_init,
-            oil_gas_gravity,
-            free_gas_gravity,
-            oil_density,
-            z_factor,
-            pres_depl,
-            temp_res,
-        ):
-            # Return unchanged saturations and properties
-            # (simulating above bubble point)
-            return gas_saturation_init, oil_saturation_init, gor_init, free_gas_gravity
-
-        monkeypatch.setattr(
-            fluid_properties,
-            "saturations_below_bubble_point",
-            saturations_below_bubble_point_mock,
-        )
-
-
 def test_accepts_single_and_list(sim_props_high_pressure, fluids, pvtnum_grid):
     res_single = effective_fluid_properties_zoned(
         sim_props_high_pressure, fluids, pvtnum_grid
@@ -254,10 +182,40 @@ def test_accepts_single_and_list(sim_props_high_pressure, fluids, pvtnum_grid):
     assert np.allclose(res_single[0].density, res_list[0].density)
 
 
-@pytest.mark.skipif(
-    not INTERNAL_EQUINOR, reason="Condensate only inside Equinor context"
-)
-def test_condensate_overwrite(sim_props_with_condensate, fluids, pvtnum_grid):
+def test_condensate_overwrite(
+    sim_props_with_condensate, fluids, pvtnum_grid, monkeypatch
+):
+    def condensate_properties(temperature, pressure, rho0, gas_oil_ratio, gas_gravity):
+        n = len(temperature)
+        return np.full(n, 1600.0), np.full(n, 600.0), np.full(n, 1.0e9)
+
+    def gas_properties(temperature, pressure, gas_gravity, model):
+        n = len(temperature)
+        return np.full(n, 2000.0), np.full(n, 200.0), np.full(n, 0.5e9)
+
+    def bp_standing(density, gas_oil_ratio, gas_gravity, temperature):
+        # Return a bubble point well below the test pressure (25 MPa) so that
+        # the bubble-point adjustment branch is not triggered.
+        n = len(density) if hasattr(density, "__len__") else 1
+        return np.full(n, 1.0e7)
+
+    def brine_properties(temperature, pressure, salinity, p_nacl, p_cacl, p_kcl):
+        n = len(temperature)
+        return np.full(n, 1500.0), np.full(n, 1030.0), np.full(n, 2.5e9)
+
+    def oil_properties(temperature, pressure, rho0, gas_oil_ratio, gas_gravity):
+        n = len(temperature)
+        return np.full(n, 1400.0), np.full(n, 800.0), np.full(n, 1.5e9)
+
+    monkeypatch.setattr(fluid_properties, "HAS_PROPRIETARY_ROCK_PHYSICS", True)
+    monkeypatch.setattr(
+        fluid_properties, "condensate_properties", condensate_properties
+    )
+    monkeypatch.setattr(fluid_properties, "gas_properties", gas_properties)
+    monkeypatch.setattr(fluid_properties, "bp_standing", bp_standing)
+    monkeypatch.setattr(fluid_properties, "brine_properties", brine_properties)
+    monkeypatch.setattr(fluid_properties, "oil_properties", oil_properties)
+
     fluids.pvt_zones[0].calculate_condensate = True
     res = effective_fluid_properties_zoned(
         sim_props_with_condensate, fluids, pvtnum_grid
@@ -270,18 +228,12 @@ def test_co2_path(sim_props_high_pressure, fluids, pvtnum_grid, monkeypatch):
     calls = {"co2": 0}
     fluids.pvt_zones[0].gas_saturation_is_co2 = True
 
-    def co2_properties(temp, pres):
+    def co2_properties(temperature, pressure, use_proprietary_model):
         calls["co2"] += 1
-        n = len(temp)
+        n = len(temperature)
         return np.full(n, 1800.0), np.full(n, 400.0), np.full(n, 0.8e9)
 
-    # Mock the appropriate module based on INTERNAL_EQUINOR
-    if INTERNAL_EQUINOR:
-        monkeypatch.setattr(fluid_properties.flag, "co2_properties", co2_properties)
-    else:
-        monkeypatch.setattr(
-            fluid_properties.span_wagner, "co2_properties", co2_properties
-        )
+    monkeypatch.setattr(fluid_properties, "co2_properties", co2_properties)
 
     effective_fluid_properties_zoned(sim_props_high_pressure, fluids, pvtnum_grid)
     assert calls["co2"] == 1
@@ -315,7 +267,7 @@ def test_list_multiple(
 
 def test_below_bubble_point_raises_error(sim_props_low_pressure, pvtnum_grid):
     """Test that pressures below bubble point trigger an error when gas_z_factor=1.0"""
-    fluids_default = StubFluids(gas_z_factor=1.0)
+    fluids_default = cast(Fluids, StubFluids(gas_z_factor=1.0))
     with pytest.raises(
         ValueError, match="Fraction of cells with pressure below oil bubble point"
     ):
@@ -326,7 +278,7 @@ def test_below_bubble_point_raises_error(sim_props_low_pressure, pvtnum_grid):
 
 def test_above_bubble_point_succeeds(sim_props_high_pressure, pvtnum_grid):
     """Test normal operation with pressures above bubble point"""
-    fluids_default = StubFluids(gas_z_factor=1.0)
+    fluids_default = cast(Fluids, StubFluids(gas_z_factor=1.0))
     res = effective_fluid_properties_zoned(
         sim_props_high_pressure, fluids_default, pvtnum_grid
     )[0][0]
@@ -337,7 +289,7 @@ def test_above_bubble_point_succeeds(sim_props_high_pressure, pvtnum_grid):
 
 def test_below_bubble_point_with_z_factor(sim_props_low_pressure, pvtnum_grid):
     """Test that setting gas_z_factor != 1.0 allows operation below bubble point"""
-    fluids_with_z = StubFluids(gas_z_factor=0.95)
+    fluids_with_z = cast(Fluids, StubFluids(gas_z_factor=0.95))
     # Should not raise an error, and should issue a warning instead
     with pytest.warns(UserWarning, match="Detected pressure below bubble point"):
         res, bp = effective_fluid_properties_zoned(

--- a/tests/test_pem.py
+++ b/tests/test_pem.py
@@ -2,11 +2,14 @@ from pathlib import Path
 
 import pytest
 
-from fmu.pem import INTERNAL_EQUINOR, pem, pem_fcn
+from fmu.pem import pem, pem_fcn
 from fmu.pem.pem_utilities import (
     PemConfig,
     get_global_params_and_dates,
     read_pem_config,
+)
+from fmu.pem.pem_utilities.rock_physics_adapter import (
+    HAS_PROPRIETARY_ROCK_PHYSICS,
 )
 
 
@@ -46,7 +49,7 @@ def test_pem_fcn(data_dir, monkeypatch):
 def test_pem_fcn_multi(data_dir, monkeypatch):
     monkeypatch.chdir(data_dir)
 
-    if not INTERNAL_EQUINOR:
+    if not HAS_PROPRIETARY_ROCK_PHYSICS:
         with pytest.raises((NotImplementedError, ImportError)):
             conf, config_dir = setup(
                 data_dir=data_dir,
@@ -69,34 +72,22 @@ def test_pem_fcn_multi(data_dir, monkeypatch):
 
 def test_pem_main(data_dir, monkeypatch):
     monkeypatch.chdir(data_dir)
-
-    if not INTERNAL_EQUINOR:
-        pem(
-            args_list=[
-                "--config-dir",
-                str((data_dir / "sim2seis" / "model").resolve()),
-                "--config-file",
-                "pem_config_no_condensate.yml",
-                "--global-dir",
-                "fmuconfig/output",
-                "--global-file",
-                "global_variables.yml",
-                "--mod-date-prefix",
-                "HIST",
-            ]
-        )
-    else:
-        pem(
-            args_list=[
-                "--config-dir",
-                str((data_dir / "sim2seis" / "model").resolve()),
-                "--config-file",
-                "pem_config_condensate_multi.yml",
-                "--global-dir",
-                "fmuconfig/output",
-                "--global-file",
-                "global_variables.yml",
-                "--mod-date-prefix",
-                "HIST",
-            ]
-        )
+    config_file = (
+        "pem_config_condensate_multi.yml"
+        if HAS_PROPRIETARY_ROCK_PHYSICS
+        else "pem_config_no_condensate.yml"
+    )
+    pem(
+        args_list=[
+            "--config-dir",
+            str((data_dir / "sim2seis" / "model").resolve()),
+            "--config-file",
+            config_file,
+            "--global-dir",
+            "fmuconfig/output",
+            "--global-file",
+            "global_variables.yml",
+            "--mod-date-prefix",
+            "HIST",
+        ]
+    )

--- a/tests/test_rock_physics_adapter.py
+++ b/tests/test_rock_physics_adapter.py
@@ -1,0 +1,159 @@
+import numpy as np
+import pytest
+
+import fmu.pem.pem_utilities.rock_physics_adapter as rock_physics_adapter
+from tests.utils.rock_physics_adapter_mocking import (
+    ensure_rock_physics_not_installed,
+    mock_installed_proprietary_rock_physics,
+)
+
+INPUT_TEMPERATURE = np.array([150.0])
+INPUT_PRESSURE = np.array([2.0e7])
+INPUT_RHO = np.array([2650.0])
+INPUT_GOR = np.array([100.0])
+INPUT_Z_FACTOR = 0.99
+INPUT_OIL_SAT = np.array([0.5])
+INPUT_GAS_SAT = np.array([0.3])
+INPUT_BRINE_SAT = np.array([0.2])
+INPUT_OIL_GAS_GRAVITY = np.array([0.8])
+INPUT_FREE_GAS_GRAVITY = np.array([0.7])
+INPUT_OIL_DENSITY = np.array([800.0])
+INPUT_PRES_DEPL = np.array([1.5e7])
+INPUT_TEMP_RES = np.array([120.0])
+
+# These tests are for ensuring the rock_physics_adapter correctly chooses
+# between the proprietary and open-source implementations, and raises errors and
+# warnings when necessary. It does not validate the correctness of the
+# underlying rock physics calculations.
+
+
+@ensure_rock_physics_not_installed
+def test_mock_with_proprietary_unavailable():
+    assert rock_physics_adapter.HAS_PROPRIETARY_ROCK_PHYSICS is False
+    assert not hasattr(rock_physics_adapter, "internal_brine_properties")
+    assert not hasattr(rock_physics_adapter, "internal_co2_properties")
+    assert not hasattr(rock_physics_adapter, "internal_bp_standing")
+    assert not hasattr(rock_physics_adapter, "internal_gas_properties")
+    assert not hasattr(rock_physics_adapter, "internal_oil_properties")
+    assert not hasattr(rock_physics_adapter, "internal_condensate_properties")
+    assert not hasattr(rock_physics_adapter, "internal_saturations_below_bubble_point")
+
+
+@mock_installed_proprietary_rock_physics
+def test_mock_with_proprietary_available():
+    assert rock_physics_adapter.HAS_PROPRIETARY_ROCK_PHYSICS is True
+    assert hasattr(rock_physics_adapter, "internal_brine_properties")
+    assert hasattr(rock_physics_adapter, "internal_co2_properties")
+    assert hasattr(rock_physics_adapter, "internal_bp_standing")
+    assert hasattr(rock_physics_adapter, "internal_gas_properties")
+    assert hasattr(rock_physics_adapter, "internal_oil_properties")
+    assert hasattr(rock_physics_adapter, "internal_condensate_properties")
+    assert hasattr(rock_physics_adapter, "internal_saturations_below_bubble_point")
+
+
+@pytest.mark.filterwarnings("error")  # fail on any unhandled/unmatched warnings
+@mock_installed_proprietary_rock_physics
+def test_co2_properties_uses_internal_path_when_available():
+    rock_physics_adapter.co2_properties(
+        INPUT_TEMPERATURE,
+        INPUT_PRESSURE,
+    )
+    rock_physics_adapter.open_co2_properties.assert_not_called()
+    rock_physics_adapter.internal_co2_properties.assert_called_once()
+
+
+@pytest.mark.filterwarnings("error")
+@ensure_rock_physics_not_installed
+def test_co2_properties_uses_open_path_when_proprietary_unavailable():
+    assert not hasattr(rock_physics_adapter, "internal_co2_properties")
+    rock_physics_adapter.co2_properties(
+        INPUT_TEMPERATURE,
+        INPUT_PRESSURE,
+    )
+    rock_physics_adapter.open_co2_properties.assert_called_once()
+
+
+@pytest.mark.filterwarnings("error")
+@mock_installed_proprietary_rock_physics
+def test_co2_properties_uses_open_path_when_opting_out_of_proprietary_model():
+    rock_physics_adapter.co2_properties(
+        INPUT_TEMPERATURE,
+        INPUT_PRESSURE,
+        use_proprietary_model=False,
+    )
+    rock_physics_adapter.open_co2_properties.assert_called_once()
+    rock_physics_adapter.internal_co2_properties.assert_not_called()
+
+
+@pytest.mark.filterwarnings("error")
+@mock_installed_proprietary_rock_physics
+def test_condensate_properties_uses_internal_path_when_available():
+    rock_physics_adapter.condensate_properties(
+        temperature=INPUT_TEMPERATURE,
+        pressure=INPUT_PRESSURE,
+        rho0=INPUT_RHO,
+        gas_oil_ratio=INPUT_GOR,
+        gas_gravity=INPUT_OIL_GAS_GRAVITY,
+    )
+    rock_physics_adapter.internal_condensate_properties.assert_called_once()
+
+
+@pytest.mark.filterwarnings("error")
+@ensure_rock_physics_not_installed
+def test_condensate_properties_raises_error_when_proprietary_unavailable():
+    assert not hasattr(rock_physics_adapter, "internal_condensate_properties")
+    with pytest.raises(
+        RuntimeError,
+        match="not possible without the proprietary rock physics package",
+    ):
+        rock_physics_adapter.condensate_properties(
+            temperature=INPUT_TEMPERATURE,
+            pressure=INPUT_PRESSURE,
+            rho0=INPUT_RHO,
+            gas_oil_ratio=INPUT_GOR,
+            gas_gravity=INPUT_OIL_GAS_GRAVITY,
+        )
+
+
+@pytest.mark.filterwarnings("error")
+@mock_installed_proprietary_rock_physics
+def test_saturations_below_bubble_point_uses_internal_path_when_available():
+    rock_physics_adapter.saturations_below_bubble_point(
+        gas_saturation_init=INPUT_GAS_SAT,
+        oil_saturation_init=INPUT_OIL_SAT,
+        brine_saturation_init=INPUT_BRINE_SAT,
+        gor_init=INPUT_GOR,
+        oil_gas_gravity=INPUT_OIL_GAS_GRAVITY,
+        free_gas_gravity=INPUT_FREE_GAS_GRAVITY,
+        oil_density=INPUT_OIL_DENSITY,
+        z_factor=INPUT_Z_FACTOR,
+        pres_depl=INPUT_PRES_DEPL,
+        temp_res=INPUT_TEMP_RES,
+    )
+    rock_physics_adapter.internal_saturations_below_bubble_point.assert_called_once()
+
+
+@pytest.mark.filterwarnings("error")
+@ensure_rock_physics_not_installed
+def test_saturations_below_bubble_point_warns_and_returns_input_when_unavailable():
+    assert not hasattr(rock_physics_adapter, "internal_saturations_below_bubble_point")
+    with pytest.warns(UserWarning, match="requires proprietary model"):
+        gas_sat, oil_sat, gor, free_gas_gravity = (
+            rock_physics_adapter.saturations_below_bubble_point(
+                gas_saturation_init=INPUT_GAS_SAT,
+                oil_saturation_init=INPUT_OIL_SAT,
+                brine_saturation_init=INPUT_BRINE_SAT,
+                gor_init=INPUT_GOR,
+                oil_gas_gravity=INPUT_OIL_GAS_GRAVITY,
+                free_gas_gravity=INPUT_FREE_GAS_GRAVITY,
+                oil_density=INPUT_OIL_DENSITY,
+                z_factor=INPUT_Z_FACTOR,
+                pres_depl=INPUT_PRES_DEPL,
+                temp_res=INPUT_TEMP_RES,
+            )
+        )
+    # function should "do nothing" if proprietary model is unavailable, outputs=inputs
+    assert np.array_equal(gas_sat, INPUT_GAS_SAT)
+    assert np.array_equal(oil_sat, INPUT_OIL_SAT)
+    assert np.array_equal(gor, INPUT_GOR)
+    assert np.array_equal(free_gas_gravity, INPUT_FREE_GAS_GRAVITY)

--- a/tests/utils/rock_physics_adapter_mocking.py
+++ b/tests/utils/rock_physics_adapter_mocking.py
@@ -1,0 +1,86 @@
+import functools
+from contextlib import ExitStack
+from unittest.mock import Mock, patch
+
+from fmu.pem.pem_utilities import rock_physics_adapter
+
+
+def _patch_rock_physics_adapter(has_proprietary_rock_physics: bool):
+    """Build a decorator that patches `HAS_PROPRIETARY_ROCK_PHYSICS` and all
+    mock functions on the `rock_physics_adapter` module.
+
+    When `has_proprietary` is True, internal_* attributes are created if missing
+    (simulating an installed proprietary package).
+    """
+
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            with ExitStack() as stack:
+                stack.enter_context(
+                    patch.object(
+                        rock_physics_adapter,
+                        "HAS_PROPRIETARY_ROCK_PHYSICS",
+                        has_proprietary_rock_physics,
+                    )
+                )
+
+                # need to patch with expected return signature
+                _SINGLE = None
+                _TRIPLE = (None, None, None)
+                _QUAD = (None, None, None, None)
+
+                for name, return_signature in [
+                    ("open_brine_properties", _TRIPLE),
+                    ("open_co2_properties", _TRIPLE),
+                    ("open_bp_standing", _SINGLE),
+                    ("open_gas_properties", _QUAD),
+                    ("open_oil_properties", _TRIPLE),
+                ]:
+                    stack.enter_context(
+                        patch.object(
+                            rock_physics_adapter,
+                            name,
+                            Mock(return_value=return_signature),
+                        )
+                    )
+                for name, return_signature in [
+                    ("internal_brine_properties", _TRIPLE),
+                    ("internal_co2_properties", _TRIPLE),
+                    ("internal_bp_standing", _SINGLE),
+                    ("internal_gas_properties", _QUAD),
+                    ("internal_oil_properties", _TRIPLE),
+                    ("internal_condensate_properties", _TRIPLE),
+                    ("internal_saturations_below_bubble_point", _QUAD),
+                ]:
+                    if has_proprietary_rock_physics:
+                        stack.enter_context(
+                            patch.object(
+                                rock_physics_adapter,
+                                name,
+                                Mock(return_value=return_signature),
+                                create=True,
+                            )
+                        )
+                    elif hasattr(rock_physics_adapter, name):
+                        original = getattr(rock_physics_adapter, name)
+                        delattr(rock_physics_adapter, name)
+                        stack.callback(setattr, rock_physics_adapter, name, original)
+                return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+ensure_rock_physics_not_installed = _patch_rock_physics_adapter(
+    has_proprietary_rock_physics=False,
+)
+"""Decorator: ensure the proprietary rock physics package can _not_ be used,
+even if it is installed in the test environment."""
+
+mock_installed_proprietary_rock_physics = _patch_rock_physics_adapter(
+    has_proprietary_rock_physics=True
+)
+"""Decorator: simulate the proprietary rock physics package being installed,
+adding mock implementations of adapter functions to assert paths."""


### PR DESCRIPTION
The runtime in-place import swapping between `rock-physics` and `rock-physics-open` has been removed in their latest versions.

This PR adds an `adapter` with explicit "swapping" based on if the internal package is available in the python environment or not. This should:
 - make behaviour easier to predict
 - stepping through the code easier
 - allows "customizing" desired behaviour based on the different internal functions
 - imports, typing etc. work as expected

The PR does not change any behaviour of fmu-pem, only refactors the internal fluid functions.