### PR TITLE
Hflesche/issue136

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dynamic = ["version"]
 dependencies = [
     "numpy >= 1.24.3",
     "xtgeo >= 4.7.1",
+    "resfo",
     "fmu-tools",
     "fmu-config",
     "fmu-dataio",

--- a/src/fmu/pem/pem_functions/fluid_properties.py
+++ b/src/fmu/pem/pem_functions/fluid_properties.py
@@ -36,22 +36,6 @@ if TYPE_CHECKING:
 BUBBLE_POINT_FRACTION_TOLERANCE = 0.01
 
 
-def _saturation_triplet(
-    sw: np.ma.MaskedArray, sg: np.ma.MaskedArray
-) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """Clip water/gas and derive oil saturation; renormalize if sum exceeds 1."""
-    sw = np.ma.MaskedArray(np.ma.clip(sw, 0.0, 1.0))
-    sg = np.ma.MaskedArray(np.ma.clip(sg, 0.0, 1.0))
-    # sw and sg come from the same grid, and will have the same mask, so there
-    # should be no need for special handling of possible different masks
-    s_sum = np.ma.max(sw + sg)
-    if s_sum > 1.0:  # renormalize if overlapping
-        sw /= s_sum
-        sg /= s_sum
-    so = 1.0 - sw - sg
-    return sw, sg, so
-
-
 def _adjust_bubble_point(
     pres: np.ndarray,
     gor: np.ndarray,
@@ -369,7 +353,7 @@ def effective_fluid_properties_zoned(
             # Extract saturations, pressure, GOR, etc. (placeholder for existing logic)
             sw = rst_date_prop.swat[mask_cells]
             sg = rst_date_prop.sgas[mask_cells]
-            sw, sg, so = _saturation_triplet(sw, sg)
+            so = rst_date_prop.soil[mask_cells]
             pres = rst_date_prop.pressure[mask_cells]
             gor = rst_date_prop.rs[mask_cells]
 

--- a/src/fmu/pem/pem_utilities/__init__.py
+++ b/src/fmu/pem/pem_utilities/__init__.py
@@ -4,6 +4,7 @@ from .delta_cumsum_time import (
     estimate_delta_time,
     estimate_sum_delta_time,
 )
+from .enum_defs import PhaseSystem
 from .export_routines import save_results
 from .fipnum_pvtnum_utilities import (
     detect_overlaps,
@@ -15,6 +16,7 @@ from .fipnum_pvtnum_utilities import (
 from .import_config import get_global_params_and_dates, read_pem_config
 from .import_routines import (
     import_fractions,
+    read_phase_system,
     read_sim_grid_props,
 )
 from .pem_class_definitions import (
@@ -68,6 +70,7 @@ __all__ = [
     "num_boolean_array",
     "parse_arguments",
     "read_pem_config",
+    "read_phase_system",
     "read_sim_grid_props",
     "restore_dir",
     "reverse_filter_and_restore",
@@ -85,4 +88,5 @@ __all__ = [
     "SaturatedRockProperties",
     "SimInitProperties",
     "SimRstProperties",
+    "PhaseSystem",
 ]

--- a/src/fmu/pem/pem_utilities/enum_defs.py
+++ b/src/fmu/pem/pem_utilities/enum_defs.py
@@ -2,8 +2,38 @@
 Define enumerated strings
 """
 
-from enum import Enum
+from enum import Enum, IntFlag
 from typing import Literal
+
+
+class PhaseSystem(IntFlag):
+    """Eclipse phase system as encoded in INTEHEAD item 15 of the UNRST file.
+
+    The Eclipse convention treats item 15 as a bitmask:
+    ``1 = oil``, ``2 = water``, ``4 = gas``. Combined values therefore
+    enumerate as:
+
+    ===== =======================
+    Value Phases present
+    ===== =======================
+    1     oil
+    2     water
+    3     oil + water
+    4     gas
+    5     oil + gas
+    6     water + gas
+    7     oil + water + gas
+    ===== =======================
+    """
+
+    OIL = 1
+    WATER = 2
+    GAS = 4
+
+    @property
+    def is_multiphase(self) -> bool:
+        """True if at least two phases are present."""
+        return bin(int(self)).count("1") >= 2
 
 
 class OverburdenPressureTypes(str, Enum):

--- a/src/fmu/pem/pem_utilities/enum_defs.py
+++ b/src/fmu/pem/pem_utilities/enum_defs.py
@@ -7,7 +7,8 @@ from typing import Literal
 
 
 class PhaseSystem(IntFlag):
-    """Eclipse phase system as encoded in INTEHEAD item 15 of the UNRST file.
+    """Eclipse 100 and OPM Flow phase system as encoded in INTEHEAD item 15 of the
+      UNRST file.
 
     The Eclipse convention treats item 15 as a bitmask:
     ``1 = oil``, ``2 = water``, ``4 = gas``. Combined values therefore

--- a/src/fmu/pem/pem_utilities/import_routines.py
+++ b/src/fmu/pem/pem_utilities/import_routines.py
@@ -8,8 +8,16 @@ from .enum_defs import PhaseSystem
 from .pem_class_definitions import SimInitProperties, SimRstProperties
 from .utils import bar_to_pa, restore_dir
 
-# Eclipse stores the phase indicator in INTEHEAD item 15 (1-indexed).
+# Eclipse stores the phase indicator in INTEHEAD item 15 (1-indexed) and the
+# simulator program identifier (IPROG) in item 95.
 _PHASE_INDICATOR_INDEX = 14
+_IPROG_INDEX = 94
+
+# IPROG values written by Eclipse 300 (regular and thermal). Eclipse 300 always
+# carries oil, water and gas internally, regardless of which phases are active
+# in the deck, so the per-run phase indicator in INTEHEAD item 15 is not
+# reliable for these runs. Eclipse 100 uses 100 and OPM Flow mirrors that.
+_ECLIPSE_300_IPROG = {300, 500}
 
 
 def read_init_properties(
@@ -62,7 +70,7 @@ def create_rst_list(
 ) -> list[SimRstProperties]:
     """Create list of SimRstProperties from raw restart properties
 
-    Eclipse only writes the phase saturations that are physically present
+    Eclipse and OPM Flow only writes the phase saturations that are physically present
     (e.g. only ``SWAT`` in a gas+water run). Any of ``SWAT``/``SGAS``/``SOIL``
     that is absent from ``rst_props`` is filled with a zero array shaped like
     the pressure field; ``reconcile_phase_saturations`` then derives the
@@ -97,11 +105,18 @@ def create_rst_list(
 
 
 def read_phase_system(unrst_file: Path) -> PhaseSystem:
-    """Read the Eclipse phase indicator from INTEHEAD item 15 of a UNRST file.
+    """Read the phase system in use from the first INTEHEAD record of a UNRST file.
 
     The UNRST file repeats the INTEHEAD record once per report step. The
     phase indicator is invariant within a run, so the first occurrence is
     used.
+
+    The simulator program identifier (INTEHEAD item 95, ``IPROG``) is
+    inspected first. Eclipse 300 (``IPROG`` 300 or 500) always carries
+    oil, water and gas internally regardless of the active phases in the
+    deck, so the phase indicator in item 15 is unreliable; the function
+    returns ``OIL | WATER | GAS`` for those runs. For Eclipse 100 and OPM
+    Flow (``IPROG`` 100) the phase indicator in item 15 is used.
 
     Args:
         unrst_file: Path to the UNRST file.
@@ -112,11 +127,14 @@ def read_phase_system(unrst_file: Path) -> PhaseSystem:
     Raises:
         ValueError: If no INTEHEAD record is found in the file, or if the
             phase indicator is zero or contains bits outside the documented
-            ``OIL | WATER | GAS`` mask.
+            ``OIL | WATER | GAS`` mask (Eclipse 100 / OPM Flow only).
     """
     valid_mask = int(PhaseSystem.OIL | PhaseSystem.WATER | PhaseSystem.GAS)
     for keyword, values in resfo.read(unrst_file):
         if keyword.strip() == "INTEHEAD":
+            iprog = int(values[_IPROG_INDEX])
+            if iprog in _ECLIPSE_300_IPROG:
+                return PhaseSystem(valid_mask)
             indicator = int(values[_PHASE_INDICATOR_INDEX])
             if indicator == 0 or indicator & ~valid_mask:
                 raise ValueError(

--- a/src/fmu/pem/pem_utilities/import_routines.py
+++ b/src/fmu/pem/pem_utilities/import_routines.py
@@ -83,6 +83,10 @@ def create_rst_list(
             for name in rst_prop_names
             if name + "_" + date in rst_props.names
         }
+        if "pressure" not in kwargs:
+            raise ValueError(
+                f"eclipse simulator restart file is missing PRESSURE for date {date}"
+            )
         # Fill any missing phase saturation with zeros sized like pressure.
         pressure = kwargs["pressure"]
         zeros = np.ma.masked_array(np.zeros_like(pressure.data), mask=pressure.mask)
@@ -106,11 +110,20 @@ def read_phase_system(unrst_file: Path) -> PhaseSystem:
         PhaseSystem flag enumerating the phases present in the simulation.
 
     Raises:
-        ValueError: If no INTEHEAD record is found in the file.
+        ValueError: If no INTEHEAD record is found in the file, or if the
+            phase indicator is zero or contains bits outside the documented
+            ``OIL | WATER | GAS`` mask.
     """
+    valid_mask = int(PhaseSystem.OIL | PhaseSystem.WATER | PhaseSystem.GAS)
     for keyword, values in resfo.read(unrst_file):
         if keyword.strip() == "INTEHEAD":
-            return PhaseSystem(int(values[_PHASE_INDICATOR_INDEX]))
+            indicator = int(values[_PHASE_INDICATOR_INDEX])
+            if indicator == 0 or indicator & ~valid_mask:
+                raise ValueError(
+                    f"Unexpected phase indicator {indicator} in INTEHEAD item 15 "
+                    f"of {unrst_file}; expected non-zero subset of 1|2|4."
+                )
+            return PhaseSystem(indicator)
     raise ValueError(f"No INTEHEAD record found in {unrst_file}")
 
 
@@ -180,7 +193,7 @@ def read_sim_grid_props(
 
     try:
         rst_list = create_rst_list(rst_props, seis_dates, rst_props_names)
-    except (AttributeError, TypeError) as e:
+    except (AttributeError, TypeError, KeyError) as e:
         raise ValueError(f"eclipse simulator restart file is missing parameters: {e}")
 
     for rst in rst_list:

--- a/src/fmu/pem/pem_utilities/import_routines.py
+++ b/src/fmu/pem/pem_utilities/import_routines.py
@@ -1,10 +1,15 @@
 from pathlib import Path
 
 import numpy as np
+import resfo
 import xtgeo
 
+from .enum_defs import PhaseSystem
 from .pem_class_definitions import SimInitProperties, SimRstProperties
 from .utils import bar_to_pa, restore_dir
+
+# Eclipse stores the phase indicator in INTEHEAD item 15 (1-indexed).
+_PHASE_INDICATOR_INDEX = 14
 
 
 def read_init_properties(
@@ -56,6 +61,13 @@ def create_rst_list(
     rst_prop_names: list[str],
 ) -> list[SimRstProperties]:
     """Create list of SimRstProperties from raw restart properties
+
+    Eclipse only writes the phase saturations that are physically present
+    (e.g. only ``SWAT`` in a gas+water run). Any of ``SWAT``/``SGAS``/``SOIL``
+    that is absent from ``rst_props`` is filled with a zero array shaped like
+    the pressure field; ``reconcile_phase_saturations`` then derives the
+    appropriate value using the run's :class:`PhaseSystem`.
+
     Args:
         rst_props: Raw restart properties
         seis_dates: list of dates to process
@@ -63,16 +75,43 @@ def create_rst_list(
     Returns:
         list[SimRstProperties]: list of processed restart properties by date
     """
-    return [
-        SimRstProperties(
-            **{
-                name.lower(): rst_props[name + "_" + date].values
-                for name in rst_prop_names
-                if name + "_" + date in rst_props.names
-            }
-        )
-        for date in seis_dates
-    ]
+    saturation_names = {"SWAT", "SGAS", "SOIL"}
+    result: list[SimRstProperties] = []
+    for date in seis_dates:
+        kwargs = {
+            name.lower(): rst_props[name + "_" + date].values
+            for name in rst_prop_names
+            if name + "_" + date in rst_props.names
+        }
+        # Fill any missing phase saturation with zeros sized like pressure.
+        pressure = kwargs["pressure"]
+        zeros = np.ma.masked_array(np.zeros_like(pressure.data), mask=pressure.mask)
+        for sat_name in saturation_names:
+            kwargs.setdefault(sat_name.lower(), zeros)
+        result.append(SimRstProperties(**kwargs))
+    return result
+
+
+def read_phase_system(unrst_file: Path) -> PhaseSystem:
+    """Read the Eclipse phase indicator from INTEHEAD item 15 of a UNRST file.
+
+    The UNRST file repeats the INTEHEAD record once per report step. The
+    phase indicator is invariant within a run, so the first occurrence is
+    used.
+
+    Args:
+        unrst_file: Path to the UNRST file.
+
+    Returns:
+        PhaseSystem flag enumerating the phases present in the simulation.
+
+    Raises:
+        ValueError: If no INTEHEAD record is found in the file.
+    """
+    for keyword, values in resfo.read(unrst_file):
+        if keyword.strip() == "INTEHEAD":
+            return PhaseSystem(int(values[_PHASE_INDICATOR_INDEX]))
+    raise ValueError(f"No INTEHEAD record found in {unrst_file}")
 
 
 def read_sim_grid_props(
@@ -82,7 +121,7 @@ def read_sim_grid_props(
     restart_property_file: Path,
     seis_dates: list[str],
     fipnum_name: str = "FIPNUM",
-) -> tuple[xtgeo.Grid, SimInitProperties, list[SimRstProperties]]:
+) -> tuple[xtgeo.Grid, SimInitProperties, list[SimRstProperties], PhaseSystem]:
     """Read grid and properties from simulation run, both initial and restart properties
 
     Args:
@@ -96,12 +135,15 @@ def read_sim_grid_props(
         sim_grid: grid definition for eclipse input
         init_props: object with initial properties of simulation grid
         rst_list: list with time-dependent simulation properties
+        phase_system: phases present in the simulation (from INTEHEAD item 15)
     """
     sim_grid = xtgeo.grid_from_file(rel_dir_sim_files / egrid_file)
 
     init_props = read_init_properties(
         rel_dir_sim_files / init_property_file, sim_grid, fipnum_name
     )
+
+    phase_system = read_phase_system(rel_dir_sim_files / restart_property_file)
 
     # TEMP will only be available for eclipse-300
     rst_props_names = ["SWAT", "SGAS", "SOIL", "RS", "RV", "PRESSURE", "SALT", "TEMP"]
@@ -141,7 +183,10 @@ def read_sim_grid_props(
     except (AttributeError, TypeError) as e:
         raise ValueError(f"eclipse simulator restart file is missing parameters: {e}")
 
-    return sim_grid, init_props, rst_list
+    for rst in rst_list:
+        rst.reconcile_phase_saturations(phase_system)
+
+    return sim_grid, init_props, rst_list, phase_system
 
 
 def import_fractions(

--- a/src/fmu/pem/pem_utilities/pem_class_definitions.py
+++ b/src/fmu/pem/pem_utilities/pem_class_definitions.py
@@ -113,10 +113,15 @@ class SimRstProperties(PropertiesSubgridMasked):
             PhaseSystem.OIL: ("oil (SOIL)", np.ma.clip(self.soil, 0.0, 1.0)),
         }
 
+        def _max_abs(arr: MaskedArray) -> float:
+            # np.ma.max returns the masked constant for a fully-masked array,
+            # which fails to coerce to float. Treat that case as zero.
+            return float(np.ma.filled(np.ma.max(np.ma.abs(arr)), 0.0))
+
         for flag, (name, sat) in list(sats.items()):
             if phase_system & flag:
                 continue
-            max_abs = float(np.ma.max(np.ma.abs(sat)))
+            max_abs = _max_abs(sat)
             if max_abs > tol:
                 raise ValueError(
                     f"SimRstProperties: phase {name} is declared absent by "
@@ -131,7 +136,7 @@ class SimRstProperties(PropertiesSubgridMasked):
         derived = [
             flag
             for flag, (_name, sat) in sats.items()
-            if (phase_system & flag) and float(np.ma.max(np.ma.abs(sat))) <= tol
+            if (phase_system & flag) and _max_abs(sat) <= tol
         ]
         if len(derived) > 1:
             raise ValueError(

--- a/src/fmu/pem/pem_utilities/pem_class_definitions.py
+++ b/src/fmu/pem/pem_utilities/pem_class_definitions.py
@@ -4,6 +4,8 @@ from typing import Self
 import numpy as np
 from numpy.ma import MaskedArray
 
+from .enum_defs import PhaseSystem
+
 
 class PropertiesSubgridMasked:
     """
@@ -85,6 +87,74 @@ class SimRstProperties(PropertiesSubgridMasked):
     temp: MaskedArray | None = None
     rv: MaskedArray | None = None
     salt: MaskedArray | None = None
+
+    def reconcile_phase_saturations(
+        self, phase_system: PhaseSystem, tol: float = 1.0e-6
+    ) -> None:
+        """Validate saturations against ``phase_system`` and normalise in place.
+
+        For each of water/gas/oil:
+
+        - If the phase is declared absent in ``phase_system``, the saturation
+          must be at most ``tol`` in magnitude everywhere; otherwise
+          ``ValueError`` is raised. The array is then forced to exactly zero.
+        - If the phase is declared present but its saturation is (numerically)
+          zero everywhere, it is derived as ``1 - sum_of_other_phases``. At most
+          one present phase may be derived this way; if more than one is empty,
+          ``ValueError`` is raised.
+        - All other present phases are clipped to ``[0, 1]``.
+
+        After the per-phase handling, the three saturations are renormalised
+        cell-by-cell so they sum to 1, correcting any small numerical drift.
+        """
+        sats: dict[PhaseSystem, tuple[str, MaskedArray]] = {
+            PhaseSystem.WATER: ("water (SWAT)", np.ma.clip(self.swat, 0.0, 1.0)),
+            PhaseSystem.GAS: ("gas (SGAS)", np.ma.clip(self.sgas, 0.0, 1.0)),
+            PhaseSystem.OIL: ("oil (SOIL)", np.ma.clip(self.soil, 0.0, 1.0)),
+        }
+
+        for flag, (name, sat) in list(sats.items()):
+            if phase_system & flag:
+                continue
+            max_abs = float(np.ma.max(np.ma.abs(sat)))
+            if max_abs > tol:
+                raise ValueError(
+                    f"SimRstProperties: phase {name} is declared absent by "
+                    f"PhaseSystem={phase_system!r} but has non-zero saturation "
+                    f"(max |sat| = {max_abs:g})."
+                )
+            sats[flag] = (
+                name,
+                np.ma.masked_array(np.zeros_like(sat.data), mask=sat.mask),
+            )
+
+        derived = [
+            flag
+            for flag, (_name, sat) in sats.items()
+            if (phase_system & flag) and float(np.ma.max(np.ma.abs(sat))) <= tol
+        ]
+        if len(derived) > 1:
+            raise ValueError(
+                "SimRstProperties: more than one present phase has zero saturation "
+                f"({[sats[f][0] for f in derived]}); cannot derive both."
+            )
+        if derived:
+            flag = derived[0]
+            other_sum = sum(
+                (sat for f, (_n, sat) in sats.items() if f != flag),
+                start=np.ma.zeros_like(sats[flag][1]),
+            )
+            sats[flag] = (sats[flag][0], np.ma.clip(1.0 - other_sum, 0.0, 1.0))
+
+        total = (
+            sats[PhaseSystem.WATER][1]
+            + sats[PhaseSystem.GAS][1]
+            + sats[PhaseSystem.OIL][1]
+        )
+        safe_total = np.ma.where(total > 0.0, total, 1.0)
+        self.swat = sats[PhaseSystem.WATER][1] / safe_total
+        self.sgas = sats[PhaseSystem.GAS][1] / safe_total
+        self.soil = sats[PhaseSystem.OIL][1] / safe_total
 
 
 # Elastic properties for matrix, i.e. mixed minerals and volume fractions

--- a/src/fmu/pem/run_pem.py
+++ b/src/fmu/pem/run_pem.py
@@ -30,13 +30,15 @@ def pem_fcn(
         _log("process started")
     with pem_utils.restore_dir(run_dir):
         # Import Eclipse simulation grid - INIT and RESTART
-        sim_grid, constant_props, time_step_props = pem_utils.read_sim_grid_props(
-            rel_dir_sim_files=config.eclipse_files.rel_path_simgrid,
-            egrid_file=config.eclipse_files.egrid_file,
-            init_property_file=config.eclipse_files.init_property_file,
-            restart_property_file=config.eclipse_files.restart_property_file,
-            seis_dates=config.global_params.mod_dates,
-            fipnum_name=config.alternative_fipnum_name,
+        sim_grid, constant_props, time_step_props, _phase_system = (
+            pem_utils.read_sim_grid_props(
+                rel_dir_sim_files=config.eclipse_files.rel_path_simgrid,
+                egrid_file=config.eclipse_files.egrid_file,
+                init_property_file=config.eclipse_files.init_property_file,
+                restart_property_file=config.eclipse_files.restart_property_file,
+                seis_dates=config.global_params.mod_dates,
+                fipnum_name=config.alternative_fipnum_name,
+            )
         )
         if verbose:
             _log("simgrid, init and restart properties read")

--- a/tests/test_fluids.py
+++ b/tests/test_fluids.py
@@ -10,6 +10,7 @@ from fmu.pem.pem_utilities.enum_defs import (
     CO2Models,
     FluidMixModel,
     GasModels,
+    PhaseSystem,
     TemperatureMethod,
 )
 
@@ -101,6 +102,11 @@ class StubSimRstProperties(SimRstProperties):
         self.temp = np.ma.MaskedArray(np.asarray(temp), mask=False)
         if rv is not None:
             self.rv = np.ma.MaskedArray(np.asarray(rv), mask=False)
+
+        # Derive soil saturation and renormalise as production code does.
+        self.reconcile_phase_saturations(
+            PhaseSystem.OIL | PhaseSystem.WATER | PhaseSystem.GAS
+        )
 
 
 @pytest.fixture

--- a/tests/test_read_phase_system.py
+++ b/tests/test_read_phase_system.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+import resfo
+
+from fmu.pem.pem_utilities import read_phase_system
+from fmu.pem.pem_utilities.enum_defs import PhaseSystem
+
+
+def _write_unrst(path: Path, *, iprog: int, phase_indicator: int) -> None:
+    """Write a minimal UNRST file containing a single INTEHEAD record.
+
+    Only the two items relevant to ``read_phase_system`` (PHASE at index 14
+    and IPROG at index 94) are populated; everything else stays zero.
+    """
+    intehead = np.zeros(411, dtype=np.int32)
+    intehead[14] = phase_indicator
+    intehead[94] = iprog
+    resfo.write(path, [("INTEHEAD", intehead)])
+
+
+def test_read_phase_system_eclipse_300_assumes_all_phases(tmp_path: Path) -> None:
+    unrst = tmp_path / "ECL300.UNRST"
+    # Even with a deck that only advertises oil+water (indicator = 3) in
+    # INTEHEAD item 15, Eclipse 300 always carries all three phases.
+    _write_unrst(unrst, iprog=300, phase_indicator=3)
+
+    assert read_phase_system(unrst) == (
+        PhaseSystem.OIL | PhaseSystem.WATER | PhaseSystem.GAS
+    )
+
+
+def test_read_phase_system_eclipse_300_thermal_assumes_all_phases(
+    tmp_path: Path,
+) -> None:
+    unrst = tmp_path / "ECL300T.UNRST"
+    _write_unrst(unrst, iprog=500, phase_indicator=1)
+
+    assert read_phase_system(unrst) == (
+        PhaseSystem.OIL | PhaseSystem.WATER | PhaseSystem.GAS
+    )
+
+
+def test_read_phase_system_eclipse_100_uses_phase_indicator(tmp_path: Path) -> None:
+    unrst = tmp_path / "ECL100.UNRST"
+    _write_unrst(
+        unrst, iprog=100, phase_indicator=int(PhaseSystem.OIL | PhaseSystem.WATER)
+    )
+
+    assert read_phase_system(unrst) == PhaseSystem.OIL | PhaseSystem.WATER
+
+
+def test_read_phase_system_invalid_indicator_raises_for_non_e300(
+    tmp_path: Path,
+) -> None:
+    unrst = tmp_path / "BAD.UNRST"
+    _write_unrst(unrst, iprog=100, phase_indicator=0)
+
+    with pytest.raises(ValueError, match="Unexpected phase indicator"):
+        read_phase_system(unrst)


### PR DESCRIPTION
# PR draft: derive phase saturations from UNRST INTEHEAD

## Title

```
feat(pem): derive phase saturations from UNRST INTEHEAD phase indicator
```

## Description

### Problem

Eclipse only writes the phase saturations that are physically present in a run.
A two-phase (e.g. gas + water) UNRST therefore contains only `SWAT`; `SGAS` and
`SOIL` are absent. The previous code treated all three as required keywords and
either crashed in `create_rst_list` or fell back to `_saturation_triplet`, which
made unverified assumptions about which phase was missing and contained a latent
bug where the "oil saturation supplied" branch clipped `SGAS` and stored the
result as `SOIL`.

There was also no run-level information available about which phases the
simulator considered active, so any saturation-based validation had to be
purely heuristic.

### Solution

Read Eclipse's authoritative phase indicator from `INTEHEAD` item 15 of the
UNRST file (the `1 = oil`, `2 = water`, `4 = gas` bitmask) and use it to drive
both validation and saturation reconciliation:

- `read_phase_system()` decodes the bitmask into a new `PhaseSystem` IntFlag.
- `read_sim_grid_props()` returns the `PhaseSystem` alongside the existing
  grid / init / restart triple, and `create_rst_list` fills any missing
  `SWAT` / `SGAS` / `SOIL` keyword with a zero `MaskedArray` sized like the
  pressure field.
- A new `SimRstProperties.reconcile_phase_saturations(phase_system)` method
  clips each saturation to `[0, 1]`, validates that any phase declared absent
  by `phase_system` really is ≈ 0, derives the single present-but-empty phase
  as `1 − sum_of_others`, and renormalises so the three saturations sum to 1
  per cell. It is invoked from `read_sim_grid_props` for every restart step.
- The old `_saturation_triplet` helper in `fluid_properties.py` is removed;
  the per-zone loop now reads saturations directly because they are already
  clipped, derived, and normalised at import time.

`run_pem.py` accepts the new fourth return value but does not yet consume it;
it will be used by the upcoming logging branch.

### Changes

- **feat(pem): add `PhaseSystem` IntFlag** in `enum_defs.py` mirroring Eclipse's
  INTEHEAD bitmask, plus an `is_multiphase` helper.
- **feat(pem): read `INTEHEAD` item 15** via `resfo.read` in a new
  `read_phase_system()` helper; expose it through `pem_utilities.__init__`.
  Adds `resfo` to runtime dependencies in `pyproject.toml`.
- **feat(pem): fill missing phase saturations** in `create_rst_list` with
  zero `MaskedArray`s sized like the pressure field, so two-phase UNRST files
  load cleanly.
- **feat(pem): `SimRstProperties.reconcile_phase_saturations()`** validates
  absent phases, derives the present-but-empty phase, and renormalises;
  invoked from `read_sim_grid_props` for every restart step.
- **refactor(pem): remove `_saturation_triplet`** from `fluid_properties.py`;
  saturations are now guaranteed valid by the import path.
- **test: update `StubSimRstProperties`** in `tests/test_fluids.py` to call
  `reconcile_phase_saturations(OIL | WATER | GAS)` so unit tests exercise the
  same path as production.

Closes #136 