### PR TITLE
hflesche/issue125 poro

### DIFF
--- a/src/fmu/pem/pem_utilities/__init__.py
+++ b/src/fmu/pem/pem_utilities/__init__.py
@@ -15,6 +15,7 @@ from .fipnum_pvtnum_utilities import (
 )
 from .import_config import get_global_params_and_dates, read_pem_config
 from .import_routines import (
+    apply_porosity_adjustment,
     import_fractions,
     read_phase_system,
     read_sim_grid_props,
@@ -54,6 +55,7 @@ __all__ = [
     "RockMatrixProperties",
     "MineralProperties",
     "Fluids",
+    "apply_porosity_adjustment",
     "bar_to_pa",
     "pa_to_bar",
     "calculate_diff_properties",

--- a/src/fmu/pem/pem_utilities/import_routines.py
+++ b/src/fmu/pem/pem_utilities/import_routines.py
@@ -6,6 +6,12 @@ import xtgeo
 
 from .enum_defs import PhaseSystem
 from .pem_class_definitions import SimInitProperties, SimRstProperties
+from .pem_config_validation import (
+    ConstantNonNetPorosity,
+    NoPorosityAdjustment,
+    PorosityAdjustment,
+    PreAdjustedPorosityGrid,
+)
 from .utils import bar_to_pa, restore_dir
 
 # Eclipse stores the phase indicator in INTEHEAD item 15 (1-indexed) and the
@@ -31,7 +37,9 @@ def read_init_properties(
         sim_grid: The simulation grid to use for reading properties
         fipnum_param: Name for zone/region parameter, normally 'FIPNUM'
     Returns:
-        SimInitProperties: The loaded initial grid properties
+        SimInitProperties: The loaded initial grid properties. ``ntg`` is
+        populated when the NTG keyword is present in the INIT file and
+        left as ``None`` otherwise.
     """
     init_props = ["PORO", "DEPTH", "PVTNUM", "AQUIFERN"] + [fipnum_param]
     sim_init_props = xtgeo.gridproperties_from_file(
@@ -59,7 +67,14 @@ def read_init_properties(
         sim_init_props[name].name.lower(): sim_init_props[name].values
         for name in sim_init_props.names
     }
-
+    try:
+        ntg_prop = xtgeo.gridproperty_from_file(
+            property_file, fformat="init", name="NTG", grid=sim_grid
+        )
+        props_dict["ntg"] = ntg_prop.values
+    except (ValueError, KeyError):
+        # NTG is optional; absence means each cell is treated as fully net.
+        pass
     return SimInitProperties(**props_dict)
 
 
@@ -257,6 +272,63 @@ def import_fractions(
     return [grid_prop.values for grid_prop in grid_props]
 
 
+def apply_porosity_adjustment(
+    adjustment: PorosityAdjustment,
+    sim_init: SimInitProperties,
+    sim_grid: xtgeo.Grid,
+    root_dir: Path,
+) -> None:
+    """Adjust ``sim_init.poro`` in-place according to the configured option.
+
+    Three options are supported:
+
+    * :class:`NoPorosityAdjustment`: leave PORO unchanged.
+    * :class:`ConstantNonNetPorosity`: use ``sim_init.ntg`` (read from the
+      Eclipse INIT file by :func:`read_init_properties`) to apply
+      ``por_tot = ntg * PORO + (1 - ntg) * non_net_porosity``.
+    * :class:`PreAdjustedPorosityGrid`: replace PORO with the values of a
+      grid parameter file (already containing the NTG-adjusted total
+      porosity).
+    """
+    if isinstance(adjustment, NoPorosityAdjustment):
+        return
+
+    if isinstance(adjustment, ConstantNonNetPorosity):
+        if sim_init.ntg is None:
+            raise ImportError(
+                "NTG is required for the constant non-net porosity adjustment "
+                "but is not present in the Eclipse INIT file."
+            )
+        ntg = np.ma.masked_array(sim_init.ntg.data, mask=sim_init.poro.mask)
+        _verify_ntg_is_non_binary(ntg)
+        sim_init.poro = ntg * sim_init.poro + (1.0 - ntg) * adjustment.non_net_porosity
+        return
+
+    if isinstance(adjustment, PreAdjustedPorosityGrid):
+        grid_file = root_dir / adjustment.rel_path / adjustment.file_name
+        try:
+            new_poro = xtgeo.gridproperty_from_file(grid_file, grid=sim_grid)
+        except (ValueError, FileNotFoundError) as exc:
+            raise ImportError(
+                f"failed to import pre-adjusted porosity grid {grid_file}"
+            ) from exc
+        except IndexError as exc:
+            raise ValueError(
+                f"pre-adjusted porosity grid {grid_file} does not match the "
+                f"simulation grid dimensions {tuple(sim_grid.dimensions)}."
+            ) from exc
+        _verify_grid_dimensions_match(new_poro, sim_grid, grid_file)
+        _verify_pre_adjusted_poro_mask_compatibility(
+            new_poro.values, sim_init.poro, grid_file
+        )
+        sim_init.poro = np.ma.masked_array(
+            new_poro.values.data, mask=sim_init.poro.mask
+        )
+        return
+
+    raise TypeError(f"unsupported porosity adjustment type: {type(adjustment)!r}")
+
+
 def adjust_mask(
     property: np.ma.MaskedArray,
     indicator: np.ma.MaskedArray,
@@ -285,3 +357,63 @@ def adjust_mask(
     ind_mask = indicator < threshold if filter_below else indicator > threshold
     property.mask = np.logical_or(property.mask, ind_mask)
     return property
+
+
+def _verify_grid_dimensions_match(
+    grid_prop: xtgeo.GridProperty,
+    sim_grid: xtgeo.Grid,
+    source: Path,
+) -> None:
+    """Raise if ``grid_prop`` does not have the same (ncol, nrow, nlay) as
+    the simulation grid.
+    """
+    grid_dims = sim_grid.dimensions
+    value_dims = tuple(grid_prop.values.shape)
+    prop_dims = (grid_prop.ncol, grid_prop.nrow, grid_prop.nlay)
+    if value_dims != tuple(grid_dims) or prop_dims != tuple(grid_dims):
+        raise ValueError(
+            f"pre-adjusted porosity grid {source} has dimensions {prop_dims} "
+            f"(values shape {value_dims}) which do not match the simulation "
+            f"grid dimensions {tuple(grid_dims)}."
+        )
+
+
+def _verify_pre_adjusted_poro_mask_compatibility(
+    new_poro: np.ma.MaskedArray,
+    reference_poro: np.ma.MaskedArray,
+    source: Path,
+) -> None:
+    """Raise if ``new_poro`` masks cells that are active in ``reference_poro``.
+
+    The pre-adjusted grid is considered invalid input if it masks cells that are
+    active in the simulation PORO mask.
+    """
+    new_mask = np.ma.getmaskarray(new_poro)
+    reference_mask = np.ma.getmaskarray(reference_poro)
+    invalid_mask = new_mask & ~reference_mask
+    if np.any(invalid_mask):
+        raise ValueError(
+            f"pre-adjusted porosity grid {source} masks active simulation cells; "
+            "input mask must be compatible with the simulation PORO mask."
+        )
+
+
+def _verify_ntg_is_non_binary(ntg: np.ma.MaskedArray, atol: float = 1.0e-3) -> None:
+    """Raise if NTG values are effectively binary (only 0 or 1 within ``atol``).
+
+    The constant non-net porosity adjustment is only meaningful when the
+    upscaled NTG is a continuous fraction; a binary NTG indicates the
+    adjustment is misconfigured.
+    """
+    values = ntg.compressed()
+    if values.size == 0:
+        return
+    is_zero_or_one = np.isclose(values, 0.0, atol=atol) | np.isclose(
+        values, 1.0, atol=atol
+    )
+    if np.all(is_zero_or_one):
+        raise ValueError(
+            "NTG read from the Eclipse INIT file is binary (all values within "
+            f"{atol} of 0 or 1); the constant non-net porosity adjustment is "
+            "only meaningful for a non-binary, fractional NTG."
+        )

--- a/src/fmu/pem/pem_utilities/pem_class_definitions.py
+++ b/src/fmu/pem/pem_utilities/pem_class_definitions.py
@@ -50,6 +50,7 @@ class SimInitProperties(PropertiesSubgridMasked):
     pvtnum: MaskedArray | None = None
     fipnum: MaskedArray | None = None
     aquifern: MaskedArray | None = None
+    ntg: MaskedArray | None = None
 
     @property
     def delta_z(self) -> MaskedArray:

--- a/src/fmu/pem/pem_utilities/pem_config_validation.py
+++ b/src/fmu/pem/pem_utilities/pem_config_validation.py
@@ -1,7 +1,7 @@
 import os
 from datetime import date
 from pathlib import Path
-from typing import Any, Self
+from typing import Any, Literal, Self
 
 import numpy as np
 from pydantic import (
@@ -167,6 +167,70 @@ class ZoneRegionMatrixParams(BaseModel):
         return v
 
 
+class NoPorosityAdjustment(BaseModel):
+    """No adjustment of the Eclipse PORO for non-binary NTG."""
+
+    model_config = ConfigDict(title="No porosity adjustment")
+
+    method: SkipJsonSchema[Literal["none"]] = "none"
+
+
+class ConstantNonNetPorosity(BaseModel):
+    """Adjust Eclipse PORO using a constant non-net porosity value.
+
+    Total porosity is computed as
+    ``por_tot = ntg * PORO + (1 - ntg) * non_net_porosity``.
+    """
+
+    model_config = ConfigDict(title="Constant non-net porosity")
+
+    method: SkipJsonSchema[Literal["constant"]] = "constant"
+    non_net_porosity: float = Field(
+        default=0.05,
+        ge=0.0,
+        le=0.4,
+        description="Constant non-net (shale) porosity, applied as "
+        "`por_tot = ntg * PORO + (1 - ntg) * non_net_porosity`.",
+    )
+
+
+class PreAdjustedPorosityGrid(BaseModel):
+    """Replace Eclipse PORO with a grid parameter where the NTG-adjustment
+    has already been performed upstream (e.g. in the geomodel).
+    """
+
+    model_config = ConfigDict(title="Pre-adjusted porosity grid")
+
+    method: SkipJsonSchema[Literal["grid_file"]] = "grid_file"
+    rel_path: Path = Field(
+        default=Path("sim2seis/input/pem"),
+        description="Directory containing the pre-adjusted porosity grid file.",
+    )
+    file_name: Path = Field(
+        description="Grid parameter file with NTG-adjusted total porosity; "
+        "replaces the PORO read from the Eclipse INIT file.",
+    )
+
+    @model_validator(mode="after")
+    def check_grid_file_exists(self, info: ValidationInfo) -> Self:
+        pre_experiment = (
+            info.context.get("pre_experiment", False) if info.context else False
+        )
+        if pre_experiment:
+            return self
+        full_name = self.rel_path / self.file_name
+        if not full_name.exists():
+            raise FileNotFoundError(
+                f"pre-adjusted porosity grid file is missing: {full_name}"
+            )
+        return self
+
+
+PorosityAdjustment = (
+    NoPorosityAdjustment | ConstantNonNetPorosity | PreAdjustedPorosityGrid
+)
+
+
 class RockMatrixProperties(BaseModel):
     """Configuration for rock matrix properties.
 
@@ -239,6 +303,15 @@ class RockMatrixProperties(BaseModel):
         default=MineralMixModel.VOIGT_REUSS_HILL,
         description="Effective medium model selection: either "
         "`hashin-shtrikman-average` or `voigt-reuss-hill`",
+    )
+    porosity_adjustment: PorosityAdjustment = Field(
+        default_factory=NoPorosityAdjustment,
+        discriminator="method",
+        description="Adjustment of Eclipse PORO for non-binary NTG. Choose one "
+        "of: `none` (no adjustment), `constant` (apply "
+        "`por_tot = ntg * PORO + (1 - ntg) * non_net_porosity`), or "
+        "`grid_file` (replace PORO with a grid parameter where the "
+        "adjustment has already been performed).",
     )
 
     @field_validator("zone_regions", mode="before")

--- a/src/fmu/pem/run_pem.py
+++ b/src/fmu/pem/run_pem.py
@@ -43,6 +43,15 @@ def pem_fcn(
         if verbose:
             _log("simgrid, init and restart properties read")
 
+        # Optionally adjust PORO for non-binary NTG (constant non-net porosity
+        # or a pre-adjusted grid parameter file).
+        pem_utils.apply_porosity_adjustment(
+            adjustment=config.rock_matrix.porosity_adjustment,
+            sim_init=constant_props,
+            sim_grid=sim_grid,
+            root_dir=run_dir,
+        )
+
         # Calculate rock properties - fluids and minerals
         # Effective mineral (matrix) properties - one set valid for all time-steps
         vsh, matrix_properties = pem_fcns.effective_mineral_properties(

--- a/tests/test_porosity_adjustment.py
+++ b/tests/test_porosity_adjustment.py
@@ -1,0 +1,328 @@
+"""Tests for the optional Eclipse-PORO adjustment for non-binary NTG.
+
+Covers both the pydantic schema (discriminated union on ``method``) and the
+runtime helper :func:`fmu.pem.pem_utilities.apply_porosity_adjustment`.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+import xtgeo
+import yaml
+
+from fmu.pem.pem_utilities import apply_porosity_adjustment
+from fmu.pem.pem_utilities.import_routines import (
+    _verify_grid_dimensions_match,
+    _verify_ntg_is_non_binary,
+)
+from fmu.pem.pem_utilities.pem_class_definitions import SimInitProperties
+from fmu.pem.pem_utilities.pem_config_validation import (
+    ConstantNonNetPorosity,
+    NoPorosityAdjustment,
+    PorosityAdjustment,
+    PreAdjustedPorosityGrid,
+    RockMatrixProperties,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sim_grid() -> xtgeo.Grid:
+    """Small 3x3x2 synthetic grid."""
+    return xtgeo.create_box_grid(dimension=(3, 3, 2))
+
+
+@pytest.fixture
+def base_poro() -> np.ma.MaskedArray:
+    """Fully-active 3x3x2 PORO field of 0.20."""
+    return np.ma.masked_array(
+        np.full((3, 3, 2), 0.20, dtype=float),
+        mask=np.zeros((3, 3, 2), dtype=bool),
+    )
+
+
+@pytest.fixture
+def sim_init(base_poro) -> SimInitProperties:
+    depth = np.ma.masked_array(np.zeros_like(base_poro.data), mask=base_poro.mask)
+    return SimInitProperties(poro=base_poro, depth=depth)
+
+
+def _add_ntg(sim_init: SimInitProperties, values: np.ndarray) -> SimInitProperties:
+    sim_init.ntg = np.ma.masked_array(values, mask=np.zeros_like(values, dtype=bool))
+    return sim_init
+
+
+def _make_gridprop(
+    sim_grid: xtgeo.Grid, values: np.ndarray, name: str = "NTG"
+) -> xtgeo.GridProperty:
+    return xtgeo.GridProperty(
+        ncol=sim_grid.ncol,
+        nrow=sim_grid.nrow,
+        nlay=sim_grid.nlay,
+        values=np.ma.masked_array(values, mask=np.zeros_like(values, dtype=bool)),
+        name=name,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Schema: discriminated union
+# ---------------------------------------------------------------------------
+
+
+def _minimal_rock_matrix_kwargs() -> dict:
+    """Minimal kwargs to construct a RockMatrixProperties; we only need a
+    valid stub to exercise the discriminator."""
+    from fmu.pem.pem_utilities.pem_config_validation import FractionFiles
+
+    return {
+        "zone_regions": [
+            {
+                "fipnum": "*",
+                "model": {
+                    "model_name": "friable",
+                    "params": {},
+                },
+            }
+        ],
+        "volume_fractions": FractionFiles.model_construct(
+            rel_path_fractions=Path("."),
+            fractions_prop_file_names=[Path("a.roff")],
+            fractions_are_mineral_fraction=False,
+        ),
+        "fraction_names": ["vsh"],
+        "fraction_minerals": ["shale"],
+        "shale_fractions": ["vsh"],
+        "complement": "quartz",
+    }
+
+
+def test_default_porosity_adjustment_is_none(data_dir):
+    """Omitting ``porosity_adjustment`` in the config defaults to no-op."""
+    config_path = data_dir / "sim2seis" / "model" / "pem_config_no_condensate.yml"
+    with config_path.open() as file_handle:
+        config_data = yaml.safe_load(file_handle)
+
+    rm = RockMatrixProperties.model_validate(
+        config_data["rock_matrix"],
+        context={"pre_experiment": True},
+    )
+    assert isinstance(rm.porosity_adjustment, NoPorosityAdjustment)
+    assert rm.porosity_adjustment.method == "none"
+
+
+def test_discriminator_picks_constant_variant():
+    parsed: PorosityAdjustment = ConstantNonNetPorosity.model_validate(
+        {"method": "constant", "non_net_porosity": 0.05}
+    )
+    assert isinstance(parsed, ConstantNonNetPorosity)
+    assert parsed.non_net_porosity == 0.05
+
+
+def test_discriminator_picks_grid_file_variant(tmp_path):
+    parsed = PreAdjustedPorosityGrid.model_validate(
+        {
+            "method": "grid_file",
+            "rel_path": str(tmp_path),
+            "file_name": "missing.roff",
+        },
+        context={"pre_experiment": True},
+    )
+    assert isinstance(parsed, PreAdjustedPorosityGrid)
+
+
+def test_pre_adjusted_grid_file_missing_raises(tmp_path):
+    with pytest.raises(Exception):
+        PreAdjustedPorosityGrid.model_validate(
+            {
+                "method": "grid_file",
+                "rel_path": str(tmp_path),
+                "file_name": "missing.roff",
+            }
+        )
+
+
+def test_pre_experiment_skips_grid_file_existence_check(tmp_path):
+    PreAdjustedPorosityGrid.model_validate(
+        {
+            "method": "grid_file",
+            "rel_path": str(tmp_path),
+            "file_name": "missing.roff",
+        },
+        context={"pre_experiment": True},
+    )
+
+
+def test_constant_non_net_porosity_out_of_range():
+    with pytest.raises(Exception):
+        ConstantNonNetPorosity.model_validate(
+            {"method": "constant", "non_net_porosity": 0.9}
+        )
+    with pytest.raises(Exception):
+        ConstantNonNetPorosity.model_validate(
+            {"method": "constant", "non_net_porosity": -0.01}
+        )
+
+
+# ---------------------------------------------------------------------------
+# apply_porosity_adjustment: no-op
+# ---------------------------------------------------------------------------
+
+
+def test_no_adjustment_leaves_poro_unchanged(sim_init, sim_grid, tmp_path):
+    original = sim_init.poro.copy()
+    apply_porosity_adjustment(
+        adjustment=NoPorosityAdjustment(),
+        sim_init=sim_init,
+        sim_grid=sim_grid,
+        root_dir=tmp_path,
+    )
+    np.testing.assert_array_equal(sim_init.poro, original)
+
+
+# ---------------------------------------------------------------------------
+# apply_porosity_adjustment: constant non-net porosity
+# ---------------------------------------------------------------------------
+
+
+def test_constant_non_net_adjustment_applies_formula(sim_init, sim_grid, tmp_path):
+    """``por_tot = ntg * PORO + (1 - ntg) * non_net_porosity``."""
+    _add_ntg(sim_init, np.full((3, 3, 2), 0.6, dtype=float))
+
+    apply_porosity_adjustment(
+        adjustment=ConstantNonNetPorosity(non_net_porosity=0.05),
+        sim_init=sim_init,
+        sim_grid=sim_grid,
+        root_dir=tmp_path,
+    )
+
+    expected = 0.6 * 0.20 + 0.4 * 0.05
+    np.testing.assert_allclose(sim_init.poro.data, expected)
+
+
+def test_constant_non_net_adjustment_raises_on_binary_ntg(sim_init, sim_grid, tmp_path):
+    ntg_values = np.where(np.indices((3, 3, 2)).sum(axis=0) % 2 == 0, 1.0, 0.0).astype(
+        float
+    )
+    _add_ntg(sim_init, ntg_values)
+
+    with pytest.raises(ValueError, match="binary"):
+        apply_porosity_adjustment(
+            adjustment=ConstantNonNetPorosity(non_net_porosity=0.05),
+            sim_init=sim_init,
+            sim_grid=sim_grid,
+            root_dir=tmp_path,
+        )
+
+
+def test_constant_non_net_adjustment_raises_when_ntg_absent(
+    sim_init, sim_grid, tmp_path
+):
+    assert sim_init.ntg is None
+    with pytest.raises(ImportError, match="NTG is required"):
+        apply_porosity_adjustment(
+            adjustment=ConstantNonNetPorosity(non_net_porosity=0.05),
+            sim_init=sim_init,
+            sim_grid=sim_grid,
+            root_dir=tmp_path,
+        )
+
+
+# ---------------------------------------------------------------------------
+# apply_porosity_adjustment: pre-adjusted grid file
+# ---------------------------------------------------------------------------
+
+
+def test_pre_adjusted_grid_replaces_poro(sim_init, sim_grid, tmp_path):
+    new_values = np.full((3, 3, 2), 0.31, dtype=float)
+    gp = _make_gridprop(sim_grid, new_values, name="PORO_TOT")
+    file_name = Path("poro_adjusted.roff")
+    gp.to_file(tmp_path / file_name, fformat="roff")
+
+    apply_porosity_adjustment(
+        adjustment=PreAdjustedPorosityGrid(rel_path=tmp_path, file_name=file_name),
+        sim_init=sim_init,
+        sim_grid=sim_grid,
+        root_dir=Path("/"),
+    )
+
+    np.testing.assert_allclose(sim_init.poro.data, 0.31)
+
+
+def test_pre_adjusted_grid_dimensions_mismatch_raises(sim_init, sim_grid, tmp_path):
+    other_grid = xtgeo.create_box_grid(dimension=(4, 4, 2))
+    new_values = np.full((4, 4, 2), 0.31, dtype=float)
+    gp = _make_gridprop(other_grid, new_values, name="PORO_TOT")
+    file_name = Path("poro_wrong_dims.roff")
+    gp.to_file(tmp_path / file_name, fformat="roff")
+
+    with pytest.raises(ValueError, match="dimensions"):
+        apply_porosity_adjustment(
+            adjustment=PreAdjustedPorosityGrid(rel_path=tmp_path, file_name=file_name),
+            sim_init=sim_init,
+            sim_grid=sim_grid,
+            root_dir=Path("/"),
+        )
+
+
+def test_pre_adjusted_grid_missing_file_raises(sim_init, sim_grid, tmp_path):
+    with pytest.raises(ImportError, match="failed to import"):
+        apply_porosity_adjustment(
+            adjustment=PreAdjustedPorosityGrid.model_construct(
+                method="grid_file",
+                rel_path=Path("."),
+                file_name=Path("does_not_exist.roff"),
+            ),
+            sim_init=sim_init,
+            sim_grid=sim_grid,
+            root_dir=tmp_path,
+        )
+
+
+def test_pre_adjusted_grid_masked_active_cells_raises(sim_init, sim_grid, tmp_path):
+    values = np.full((3, 3, 2), 0.31, dtype=float)
+    mask = np.zeros((3, 3, 2), dtype=bool)
+    mask[0, 0, 0] = True
+    gp = xtgeo.GridProperty(
+        ncol=sim_grid.ncol,
+        nrow=sim_grid.nrow,
+        nlay=sim_grid.nlay,
+        values=np.ma.masked_array(values, mask=mask),
+        name="PORO_TOT",
+    )
+    file_name = Path("poro_mask_mismatch.roff")
+    gp.to_file(tmp_path / file_name, fformat="roff")
+
+    with pytest.raises(ValueError, match="masks active simulation cells"):
+        apply_porosity_adjustment(
+            adjustment=PreAdjustedPorosityGrid(rel_path=tmp_path, file_name=file_name),
+            sim_init=sim_init,
+            sim_grid=sim_grid,
+            root_dir=Path("/"),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Internal verification helpers
+# ---------------------------------------------------------------------------
+
+
+def test_verify_grid_dimensions_match_accepts_matching(sim_grid):
+    gp = _make_gridprop(sim_grid, np.zeros((3, 3, 2)), name="X")
+    _verify_grid_dimensions_match(gp, sim_grid, Path("any"))
+
+
+def test_verify_ntg_non_binary_accepts_fractional():
+    arr = np.ma.masked_array(np.array([0.2, 0.5, 0.8]), mask=[False, False, False])
+    _verify_ntg_is_non_binary(arr)
+
+
+def test_verify_ntg_non_binary_rejects_all_zero_or_one():
+    arr = np.ma.masked_array(
+        np.array([0.0, 1.0, 1.0, 0.0]), mask=[False, False, False, False]
+    )
+    with pytest.raises(ValueError, match="binary"):
+        _verify_ntg_is_non_binary(arr)


### PR DESCRIPTION
# Optional Eclipse-PORO adjustment for non-binary NTG

Closes #125

## Problem

`fmu-pem` reads `PORO` directly from the Eclipse INIT file and treats it as the total porosity used by all rock-physics models. When the simulation grid has non-binary NTG (e.g. an upscaled geomodel where shale and sand are blended within a cell), the INIT `PORO` is the *net* porosity only — the non-net fraction is silently ignored. This biases the elastic properties high.

There was no way to express, in `pem_config.yml`, how the user wants the non-net portion of each cell to contribute to the total porosity.

## Solution

Add an optional `porosity_adjustment` field on `RockMatrixProperties`, modelled as a pydantic **discriminated union** on a `method` tag with three variants:

| `method`     | Behaviour                                                                                                              |
|--------------|------------------------------------------------------------------------------------------------------------------------|
| `none`       | Default. Leave `PORO` unchanged (current behaviour).                                                                  |
| `constant`   | Apply `por_tot = ntg * PORO + (1 - ntg) * non_net_porosity` using NTG from the INIT file and a configured constant.   |
| `grid_file`  | Replace `PORO` with the values of a grid-parameter file where the NTG-adjustment has already been performed upstream. |

NTG is now read by `read_init_properties` and stored on `SimInitProperties.ntg` (optional — `None` if the keyword is absent). The new `apply_porosity_adjustment` helper runs once, immediately after `read_sim_grid_props`, and mutates `sim_init.poro` in place. Safety checks reject misconfigurations:

- `constant` raises `ImportError` if NTG is not in the INIT file, and `ValueError` if the read NTG is effectively binary (all values within 1e-3 of 0 or 1).
- `grid_file` verifies the parameter grid's dimensions match the simulation grid (`values.shape` and `(ncol, nrow, nlay)`).
- The `grid_file` variant has a `model_validator` that checks file existence at config-load time, gated by the `pre_experiment` context flag so ERT `validate_pre_experiment` does not fail on missing per-realization paths.

## Changes

### `feat(config): add porosity_adjustment discriminated union`
- `src/fmu/pem/pem_utilities/pem_config_validation.py`: add `NoPorosityAdjustment`, `ConstantNonNetPorosity`, `PreAdjustedPorosityGrid` and the `PorosityAdjustment` union; wire `RockMatrixProperties.porosity_adjustment` with `default_factory=NoPorosityAdjustment` and `discriminator="method"`. `SkipJsonSchema[Literal[...]]` on `method` keeps the schema clean. `PreAdjustedPorosityGrid.check_grid_file_exists` honours the `pre_experiment` context.

### `feat(pem): read NTG from INIT and apply porosity adjustment`
- `src/fmu/pem/pem_utilities/pem_class_definitions.py`: add `ntg: MaskedArray | None = None` to `SimInitProperties`.
- `src/fmu/pem/pem_utilities/import_routines.py`:
  - `read_init_properties` optionally reads the `NTG` keyword into `props_dict["ntg"]`.
  - new `apply_porosity_adjustment(adjustment, sim_init, sim_grid, root_dir)` dispatches on the union variant. The `grid_file` branch loads the file via the full `root_dir / rel_path / file_name` path (no `chdir`).
  - private helpers `_verify_grid_dimensions_match` and `_verify_ntg_is_non_binary`.
- `src/fmu/pem/pem_utilities/__init__.py`: export `apply_porosity_adjustment`.
- `src/fmu/pem/run_pem.py`: call `apply_porosity_adjustment` immediately after `read_sim_grid_props`.

### `test(pem): cover porosity_adjustment schema and runtime helper`
- `tests/test_porosity_adjustment.py`: 16 tests covering
  - default is `NoPorosityAdjustment`, discriminator routes `constant` and `grid_file` to the right subtype, `non_net_porosity` range, missing-file existence check, `pre_experiment` bypass;
  - no-op leaves `PORO` unchanged; constant formula correctness; binary-NTG and missing-NTG rejections;
  - `grid_file` replaces `PORO`, mismatched dimensions raise `ValueError`, missing file raises `ImportError`;
  - direct unit tests for both verifier helpers.

## Test results

`pytest tests/ -q --deselect tests/test_ert_hooks.py::test_pem_through_ert --deselect tests/test_ert_hooks_condensate.py` → **113 passed, none failed**

## Example YAML

```yaml
rock_matrix:
  # ... existing fields ...
  porosity_adjustment:
    method: constant
    non_net_porosity: 0.05
```

```yaml
rock_matrix:
  porosity_adjustment:
    method: grid_file
    rel_path: sim2seis/input/pem
    file_name: poro_total.roff
```

Omitting `porosity_adjustment` preserves current behaviour exactly.