### PR TITLE
Fix/error messages

### DIFF
--- a/src/fmu/pem/forward_models/pem_model.py
+++ b/src/fmu/pem/forward_models/pem_model.py
@@ -55,7 +55,9 @@ class PetroElasticModel(ForwardModelStepPlugin):
             with restore_dir(args.model_dir):
                 _ = read_pem_config(args.config_file, pre_experiment=True)
         except Exception as e:
-            raise ForwardModelStepValidationError(f"pem validation failed:\n {str(e)}")
+            raise ForwardModelStepValidationError(
+                f"pem pre-experiment validation failed: {str(e)}"
+            )
 
     @staticmethod
     def documentation() -> ForwardModelStepDocumentation | None:

--- a/src/fmu/pem/pem_functions/effective_pressure.py
+++ b/src/fmu/pem/pem_functions/effective_pressure.py
@@ -92,7 +92,6 @@ def estimate_pressure(
     # Bulk density calculation needs to be zone-aware for patchy cement models
     fl_density = [fluid.density for fluid in fluid_props]
 
-    # Check if any zone uses patchy cement model and needs special handling
     bulk_density = []
     for fl_dens in fl_density:
         bulk_dens_grid = np.ma.masked_array(
@@ -113,6 +112,7 @@ def estimate_pressure(
             # Check if this zone uses patchy cement model
             is_patchy_cement = zone_region.model.model_name == RPMType.PATCHY_CEMENT
 
+            # Check if any zone uses patchy cement model and needs special handling
             if is_patchy_cement:
                 # Get cement fraction and density for patchy cement model
                 cement_fraction = zone_region.model.parameters.cement_fraction
@@ -137,7 +137,7 @@ def estimate_pressure(
             bulk_density.append(bulk_dens_grid)
 
     # Calculate overburden pressure per zone (time-independent)
-    # Initialize overburden pressure grid
+    # Initialize overburden pressure grid to NaN
     overburden_pressure_grid = np.ma.masked_array(
         np.full(sim_init.depth.shape, np.nan, dtype=float), mask=fipnum_mask
     )

--- a/src/fmu/pem/pem_functions/fluid_properties.py
+++ b/src/fmu/pem/pem_functions/fluid_properties.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import warnings
 from math import isclose
 from typing import TYPE_CHECKING
 
@@ -27,6 +26,7 @@ from fmu.pem.pem_utilities.rock_physics_adapter import (
     oil_properties,
     saturations_below_bubble_point,
 )
+from fmu.pem.pem_utilities.utils import pem_logger
 
 if TYPE_CHECKING:
     from fmu.pem.pem_utilities.pem_config_validation import PVTZone
@@ -80,7 +80,7 @@ def _adjust_bubble_point(
                 "file for each PVTNUM zone, e.g.: 'gas_z_factor: 0.97' "
                 "The gas Z-factor must deviate from 1.0."
             )
-        warnings.warn(
+        pem_logger.warning(
             f"Detected pressure below bubble point for oil in {np.sum(idx_below)} "
             f"cells, this is {frac_below:.3f} of total number of cells."
         )

--- a/src/fmu/pem/pem_functions/mineral_properties.py
+++ b/src/fmu/pem/pem_functions/mineral_properties.py
@@ -29,6 +29,8 @@ from fmu.pem.pem_utilities.pem_config_validation import (
 )
 from fmu.pem.pem_utilities.utils import pem_logger
 
+EPS = 1.0e-6
+
 
 def effective_mineral_properties(
     root_dir: Path,
@@ -202,10 +204,15 @@ def normalize_mineral_fractions(
             )
             fracs[i] = np.ma.MaskedArray(np.ma.clip(frac, 0.0, 1.0))
 
-    # Adjust values so that no cells exceed normalize_sum
+    # Adjust values so that no cells exceed normalize_sum. Issue a warning only if the
+    # sum exceeds the target sum by a tolerance
     tot_fractions = sum(fracs)
+    if np.ma.any(tot_fractions > normalize_sum + EPS):
+        pem_logger.warning(
+            "sum of fractions exceeds limit by maximum "
+            f"{np.max(tot_fractions - normalize_sum):.3f}, rescaled to range"
+        )
     if np.ma.any(tot_fractions > normalize_sum):
-        pem_logger.warning("sum of fractions has values above limit, rescaled to range")
         scale_factor = np.ma.max(tot_fractions / normalize_sum)
         for i, frac in enumerate(fracs):
             fracs[i] /= scale_factor

--- a/src/fmu/pem/pem_functions/mineral_properties.py
+++ b/src/fmu/pem/pem_functions/mineral_properties.py
@@ -225,5 +225,5 @@ def normalize_mineral_fractions(
     try:
         np.testing.assert_allclose(sum(fracs), 1.0, rtol=1.0e-6, atol=1.0e-6)
     except AssertionError as e:
-        raise ValueError(f"mineral fractions do not sum to 1: {e}") from e
+        raise ValueError(f"mineral fractions do not sum to 1: {e}.\n") from e
     return names, fracs

--- a/src/fmu/pem/pem_functions/mineral_properties.py
+++ b/src/fmu/pem/pem_functions/mineral_properties.py
@@ -4,7 +4,6 @@ the volume fractions.
 """
 
 from pathlib import Path
-from warnings import warn
 
 import numpy as np
 from rock_physics_open.equinor_utilities.std_functions import (
@@ -28,6 +27,7 @@ from fmu.pem.pem_utilities.enum_defs import MineralMixModel
 from fmu.pem.pem_utilities.pem_config_validation import (
     MineralProperties,
 )
+from fmu.pem.pem_utilities.utils import pem_logger
 
 
 def effective_mineral_properties(
@@ -196,20 +196,16 @@ def normalize_mineral_fractions(
     # Demand values in the range [0.0, 1.0]
     for i, frac in enumerate(fracs):
         if np.any(frac < 0.0) or np.any(frac > 1.0):
-            warn(
-                f"fraction {names[i]} has values outside of range 0.0 to 1.0,"
-                f"clipped to range",
-                UserWarning,
+            pem_logger.warning(
+                "fraction %s has values outside of range 0.0 to 1.0, clipped to range",
+                names[i],
             )
             fracs[i] = np.ma.MaskedArray(np.ma.clip(frac, 0.0, 1.0))
 
     # Adjust values so that no cells exceed normalize_sum
     tot_fractions = sum(fracs)
     if np.ma.any(tot_fractions > normalize_sum):
-        warn(
-            "sum of fractions has values above limit, rescaled to range",
-            UserWarning,
-        )
+        pem_logger.warning("sum of fractions has values above limit, rescaled to range")
         scale_factor = np.ma.max(tot_fractions / normalize_sum)
         for i, frac in enumerate(fracs):
             fracs[i] /= scale_factor

--- a/src/fmu/pem/pem_functions/pressure_sensitivity.py
+++ b/src/fmu/pem/pem_functions/pressure_sensitivity.py
@@ -180,7 +180,7 @@ def _extract_input_properties(
         k, mu = moduli(in_situ_dict[vp_key], in_situ_dict[vs_key], rho)
         return k, mu
     raise PressureSensitivityInputError(
-        f"For VP_VS mode pressure regression model, either ({vp_key}, "
+        f"For K_MU mode pressure regression model, either ({vp_key}, "
         f"{vs_key}) or ({k_key}, {mu_key}) is needed"
     )
 
@@ -354,8 +354,8 @@ def apply_dry_rock_pressure_sensitivity_model(
         )
     raise TypeError(
         f"Unsupported model type for pressure sensitivity: {type(model)}. \n"
-        f"Available options for regression based models are "
-        f"{RegressionPressureModelTypes.options()}."
+        "Available options for regression based models are "
+        f"{RegressionPressureModelTypes.options()}. "
         f"Available options for physics based models are "
         f"{PhysicsPressureModelTypes.options()}."
     )
@@ -400,7 +400,7 @@ def _apply_physics_model(
     # Validate required inputs for physics models
     if mineral_properties is None:
         raise PressureSensitivityInputError(
-            "Physics-based pressure seisntivity models require mineral_properties"
+            "Physics-based pressure sensitivity models require mineral_properties"
         )
 
     required_keys = {

--- a/src/fmu/pem/pem_functions/pressure_sensitivity.py
+++ b/src/fmu/pem/pem_functions/pressure_sensitivity.py
@@ -9,6 +9,8 @@ import numpy as np
 
 from fmu.pem.pem_utilities.enum_defs import (
     ParameterTypes,
+    PhysicsPressureModelTypes,
+    RegressionPressureModelTypes,
     RegressionPressureParameterTypes,
 )
 from fmu.pem.pem_utilities.pem_class_definitions import EffectiveMineralProperties
@@ -167,7 +169,8 @@ def _extract_input_properties(
             vp, vs = velocity(in_situ_dict[k_key], in_situ_dict[mu_key], rho)[0:2]
             return vp, vs
         raise PressureSensitivityInputError(
-            f"For VP_VS mode, need either ({vp_key}, {vs_key}) or ({k_key}, {mu_key})"
+            f"For VP_VS mode pressure regression model, either ({vp_key}, "
+            f"{vs_key}) or ({k_key}, {mu_key}) is needed"
         )
     # K_MU mode
     if has_moduli:
@@ -177,7 +180,8 @@ def _extract_input_properties(
         k, mu = moduli(in_situ_dict[vp_key], in_situ_dict[vs_key], rho)
         return k, mu
     raise PressureSensitivityInputError(
-        f"For K_MU mode, need either ({k_key}, {mu_key}) or ({vp_key}, {vs_key})"
+        f"For VP_VS mode pressure regression model, either ({vp_key}, "
+        f"{vs_key}) or ({k_key}, {mu_key}) is needed"
     )
 
 
@@ -348,7 +352,13 @@ def apply_dry_rock_pressure_sensitivity_model(
             mineral_properties,
             cement_properties,
         )
-    raise TypeError(f"Unsupported model type: {type(model)}")
+    raise TypeError(
+        f"Unsupported model type for pressure sensitivity: {type(model)}. \n"
+        f"Available options for regression based models are "
+        f"{RegressionPressureModelTypes.options()}."
+        f"Available options for physics based models are "
+        f"{PhysicsPressureModelTypes.options()}."
+    )
 
 
 def _apply_regression_model(
@@ -390,7 +400,7 @@ def _apply_physics_model(
     # Validate required inputs for physics models
     if mineral_properties is None:
         raise PressureSensitivityInputError(
-            "Physics-based models require mineral_properties"
+            "Physics-based pressure seisntivity models require mineral_properties"
         )
 
     required_keys = {

--- a/src/fmu/pem/pem_functions/regression_models.py
+++ b/src/fmu/pem/pem_functions/regression_models.py
@@ -34,6 +34,7 @@ from fmu.pem.pem_utilities.rpm_models import (
     PhysicsModelPressureSensitivity,
     VpVsRegressionParams,
 )
+from fmu.pem.pem_utilities.utils import pem_logger
 
 from .pressure_sensitivity import (
     apply_dry_rock_pressure_sensitivity_model,
@@ -223,6 +224,16 @@ def run_regression_models(
                     k1=k_sand, mu1=mu_sand, k2=k_shale, mu2=mu_shale, f1=(1.0 - tmp_vsh)
                 )
 
+        # Give the user a chance to interpret non-physical values
+        if np.any(k_dry > tmp_min_k):
+            pem_logger.warning(
+                "dry rock properties exceeding mineral properties for bulk modulus "
+                f"are detected for {int(np.sum(k_dry > tmp_min_k))} cells. It is "
+                "recommended to investigate that regression parameters are valid "
+                f"for a porosity range of {np.min(tmp_por):.2f} to "
+                f"{np.max(tmp_por):.2f}"
+            )
+
         # Perform pressure correction on dry rock properties
         if time_step > 0 and rock_matrix.pressure_sensitivity:
             # Prepare in-situ properties dictionary based on what we have
@@ -271,6 +282,17 @@ def run_regression_models(
                 cement_properties=cement_props,
             )
 
+            # Provide logging information that can identify pressure changes
+            # leading to non-physical dry rock properties
+            added_non_physical_dry_rock_cells = np.logical_xor(
+                depleted_props[ParameterTypes.K.value] > tmp_min_k, k_dry > tmp_min_k
+            )
+            if np.any(added_non_physical_dry_rock_cells):
+                pem_logger.warning(
+                    "pressure sensitivity modelling has increased the number of cells "
+                    "with dry rock bulk modulus exceeding mineral bulk modulus by "
+                    f"{int(np.sum(added_non_physical_dry_rock_cells))}"
+                )
             # Update dry properties with pressure-corrected values
             k_dry = depleted_props[ParameterTypes.K.value]
             mu = depleted_props[ParameterTypes.MU.value]
@@ -280,6 +302,14 @@ def run_regression_models(
         k_sat = gassmann(k_dry, tmp_por, tmp_fl_prop_k, tmp_min_k)
         rho_sat = rho_dry + tmp_por * tmp_fl_prop_rho
         vp, vs = velocity(k_sat, mu, rho_sat)[0:2]
+
+        # Provide logging information about possible non-physical values from
+        # Gassmann fluid substitution
+        if np.any(np.isnan(k_sat)):
+            pem_logger.warning(
+                "Fluid substitution (Gassmann model) found non-physical values in "
+                f"{int(np.sum(np.isnan(k_sat)))} cells, the value is set to NaN"
+            )
 
         vp, vs, rho_sat, k_dry, mu, rho_dry = reverse_filter_and_restore(
             mask, vp, vs, rho_sat, k_dry, mu, rho_dry

--- a/src/fmu/pem/pem_functions/run_friable_model.py
+++ b/src/fmu/pem/pem_functions/run_friable_model.py
@@ -20,6 +20,7 @@ from fmu.pem.pem_utilities import (
 from fmu.pem.pem_utilities.enum_defs import (
     ParameterTypes,
 )
+from fmu.pem.pem_utilities.utils import pem_logger
 
 from .pressure_sensitivity import apply_dry_rock_pressure_sensitivity_model
 
@@ -131,11 +132,28 @@ def run_friable(
             k_dry = depl_props[ParameterTypes.K.value]
             mu = depl_props[ParameterTypes.MU.value]
 
+            # Give the user a chance to interpret non-physical values
+            if np.any(k_dry > tmp_min_k):
+                pem_logger.warning(
+                    "dry rock properties exceeding mineral properties for bulk modulus "
+                    f"are detected for {int(np.sum(k_dry > tmp_min_k))} cells. It is "
+                    "recommended to investigate that the pressure sensitivity model "
+                    f"is valid for a depletion of {np.max(init_press - tmp_pres):.2f}"
+                )
+
         # Saturate rock
         k_sat = gassmann(k_dry, tmp_por, tmp_fl_prop_k, tmp_min_k)
         rho_dry = (1.0 - tmp_por) * tmp_min_rho
         rho_sat = rho_dry + tmp_por * tmp_fl_prop_rho
         vp, vs = velocity(k_sat, mu, rho_sat)[0:2]
+
+        # Provide logging information about possible non-physical values from
+        # Gassmann fluid substitution
+        if np.any(np.isnan(k_sat)):
+            pem_logger.warning(
+                "Fluid substitution (Gassmann model) found non-physical values in "
+                f"{int(np.sum(np.isnan(k_sat)))} cells, the value is set to NaN"
+            )
 
         # Restore original size and shape
         vp, vs, rho_sat, k_dry_out, mu_out, rho_dry_out = reverse_filter_and_restore(

--- a/src/fmu/pem/pem_functions/run_patchy_cement_model.py
+++ b/src/fmu/pem/pem_functions/run_patchy_cement_model.py
@@ -16,6 +16,7 @@ from fmu.pem.pem_utilities import (
     reverse_filter_and_restore,
 )
 from fmu.pem.pem_utilities.enum_defs import ParameterTypes
+from fmu.pem.pem_utilities.utils import pem_logger
 
 from .pressure_sensitivity import apply_dry_rock_pressure_sensitivity_model
 
@@ -141,10 +142,27 @@ def run_patchy_cement(
             k_dry = depl_props[ParameterTypes.K.value]
             mu = depl_props[ParameterTypes.MU.value]
 
+            # Give the user a chance to interpret non-physical values
+            if np.any(k_dry > tmp_min_k):
+                pem_logger.warning(
+                    "dry rock properties exceeding mineral properties for bulk modulus "
+                    f"are detected for {int(np.sum(k_dry > tmp_min_k))} cells. It is "
+                    "recommended to investigate that the pressure sensitivity model "
+                    f"is valid for a depletion of {np.max(init_pres - tmp_pres):.2f}"
+                )
+
         # Saturate rock
         k_sat = gassmann(k_dry, tmp_por, tmp_fl_prop_k, tmp_min_k)
         rho_sat = rho_dry + tmp_por * tmp_fl_prop_rho
         vp, vs = velocity(k_sat, mu, rho_sat)[0:2]
+
+        # Provide logging information about possible non-physical values from
+        # Gassmann fluid substitution
+        if np.any(np.isnan(k_sat)):
+            pem_logger.warning(
+                "Fluid substitution (Gassmann model) found non-physical values in "
+                f"{int(np.sum(np.isnan(k_sat)))} cells, the value is set to NaN"
+            )
 
         vp, vs, rho_sat, k_dry_out, mu_out, rho_dry_out = reverse_filter_and_restore(
             mask, vp, vs, rho_sat, k_dry, mu, rho_dry

--- a/src/fmu/pem/pem_functions/run_t_matrix_model.py
+++ b/src/fmu/pem/pem_functions/run_t_matrix_model.py
@@ -17,6 +17,7 @@ from fmu.pem.pem_utilities import (
     filter_and_one_dim,
     reverse_filter_and_restore,
 )
+from fmu.pem.pem_utilities.utils import pem_logger
 
 from .run_patchy_cement_model import _verify_inputs
 
@@ -149,7 +150,7 @@ def run_t_matrix_model(
                 vsh,
             )
         if t_mat_params.t_mat_model_version == "PETEC":
-            vp, vs, rho, k, mu = run_t_matrix_forward_model_with_opt_params_petec(
+            vp, vs, rho, k, _mu = run_t_matrix_forward_model_with_opt_params_petec(
                 tmp_min_k,
                 tmp_min_mu,
                 tmp_min_rho,
@@ -164,7 +165,7 @@ def run_t_matrix_model(
                 str(petec_parameter_file),
             )
         else:
-            vp, vs, rho, k, mu = run_t_matrix_forward_model_with_opt_params_exp(
+            vp, vs, rho, k, _mu = run_t_matrix_forward_model_with_opt_params_exp(
                 tmp_fl_k,
                 tmp_fl_rho,
                 tmp_por,
@@ -176,6 +177,14 @@ def run_t_matrix_model(
                 t_mat_params.freq,
                 str(exp_parameter_file),
             )
+        # Give the user information of non-physical values in the saturated rock
+        if np.any(np.isnan(k)):
+            pem_logger.warning(
+                "non-physical values for saturated rock by T-Matrix model "
+                f"are found in {int(np.sum(np.isnan(k)))} cells. A combination of "
+                "low aspect ratio and high porosity values is the likely cause"
+            )
+
         if time_step > 0 and rock_matrix.pressure_sensitivity:
             vp, vs, rho, _, _ = carbonate_pressure_model(
                 vp,
@@ -192,6 +201,12 @@ def run_t_matrix_model(
                 pres_model_vs,
                 model_directory.absolute(),
                 False,
+            )
+        if np.sum(np.isnan(vp)) > np.sum(np.isnan(k)):
+            # Give information about added NaN cells from pressure sensitivity model
+            pem_logger.warning(
+                "pressure sensitivity model for T-Matrix added "
+                f"{np.sum(np.isnan(vp)) - np.sum(np.isnan(k))} non-physical cells"
             )
         vp, vs, rho = reverse_filter_and_restore(mask, vp, vs, rho)
         props = SaturatedRockProperties(vp=vp, vs=vs, density=rho)

--- a/src/fmu/pem/pem_utilities/argument_parser.py
+++ b/src/fmu/pem/pem_utilities/argument_parser.py
@@ -11,7 +11,7 @@ def _str2bool(value: object) -> bool:
     if text in {"0", "false", "f", "no", "n", "off"}:
         return False
     raise argparse.ArgumentTypeError(
-        f"Invalid boolean value: {value!r}. Expected true/false."
+        f"Argument parser: Invalid boolean value: {value!r}. Expected true/false."
     )
 
 

--- a/src/fmu/pem/pem_utilities/delta_cumsum_time.py
+++ b/src/fmu/pem/pem_utilities/delta_cumsum_time.py
@@ -83,8 +83,8 @@ def estimate_sum_delta_time(
     """Calculate TWT (two-way-time) for seismic signal for each restart date
 
     Args:
-        constant_props: constant properties, here the delta Z property of the eclipse
-            grid is used
+        constant_props: constant properties, here the delta Z property of the
+            reservoir simulator grid is used
         sat_rock_props: effective properties for the saturated rock per restart date
         config: configuration parameters
 

--- a/src/fmu/pem/pem_utilities/enum_defs.py
+++ b/src/fmu/pem/pem_utilities/enum_defs.py
@@ -6,6 +6,14 @@ from enum import Enum, IntFlag
 from typing import Literal
 
 
+class _OptionsMixin:
+    """Mixin providing a comma-separated list of valid values for error messages."""
+
+    @classmethod
+    def options(cls) -> str:
+        return ", ".join(m.value for m in cls)
+
+
 class PhaseSystem(IntFlag):
     """Eclipse 100 and OPM Flow phase system as encoded in INTEHEAD item 15 of the
       UNRST file.
@@ -37,50 +45,50 @@ class PhaseSystem(IntFlag):
         return bin(int(self)).count("1") >= 2
 
 
-class OverburdenPressureTypes(str, Enum):
+class OverburdenPressureTypes(_OptionsMixin, str, Enum):
     CONSTANT = "constant"
     TREND = "trend"
 
 
-class Lithology(str, Enum):
+class Lithology(_OptionsMixin, str, Enum):
     SILICICLASTICS = "siliciclastics"
     CARBONATE = "carbonate"
 
 
-class MineralMixModel(str, Enum):
+class MineralMixModel(_OptionsMixin, str, Enum):
     VOIGT_REUSS_HILL = "voigt-reuss-hill"
     HASHIN_SHTRIKMAN = "hashin-shtrikman-average"
 
 
-class FluidMixModel(str, Enum):
+class FluidMixModel(_OptionsMixin, str, Enum):
     WOOD = "wood"
     BRIE = "brie"
 
 
-class SaveTypes(str, Enum):
+class SaveTypes(_OptionsMixin, str, Enum):
     SAVE_TO_DISK = "save_results_to_disk"
     SAVE_INTERMEDIATE_RESULTS = "save_intermediate_results"
     SAVE_RESULTS_TO_CSV = "save_results_to_csv"
 
 
-class CO2Models(str, Enum):
+class CO2Models(_OptionsMixin, str, Enum):
     FLAG = "flag"
     SPAN_WAGNER = "span_wagner"
 
 
-class RegressionModelLithologies(str, Enum):
+class RegressionModelLithologies(_OptionsMixin, str, Enum):
     SANDSTONE = "sandstone"
     SHALE = "shale"
 
 
-class RPMType(str, Enum):
+class RPMType(_OptionsMixin, str, Enum):
     PATCHY_CEMENT = "patchy_cement"
     FRIABLE = "friable"
     T_MATRIX = "t_matrix"
     REGRESSION = "regression"
 
 
-class GasModels(str, Enum):
+class GasModels(_OptionsMixin, str, Enum):
     GLOBAL = "Global"
     LIGHT = "Light"
     HC2016 = "HC2016"
@@ -92,18 +100,18 @@ class GasModels(str, Enum):
 CoordinationNumberFunction = Literal["PorBased", "ConstVal"]
 
 
-class TemperatureMethod(str, Enum):
+class TemperatureMethod(_OptionsMixin, str, Enum):
     CONSTANT = "constant"
     FROMSIM = "from_sim"
 
 
-class DifferenceMethod(str, Enum):
+class DifferenceMethod(_OptionsMixin, str, Enum):
     DIFF = "diff"
     DIFFPERCENT = "diffpercent"
     RATIO = "ratio"
 
 
-class DifferenceAttribute(str, Enum):
+class DifferenceAttribute(_OptionsMixin, str, Enum):
     AI = "ai"
     VPVS = "vpvs"
     SI = "si"
@@ -127,17 +135,22 @@ class DifferenceAttribute(str, Enum):
     OVERBURDEN_PRESSURE = "overburden_pressure"
 
 
-class RegressionPressureModelTypes(str, Enum):
+class RegressionPressureModelTypes(_OptionsMixin, str, Enum):
     EXPONENTIAL = "exponential"
     POLYNOMIAL = "polynomial"
 
 
-class RegressionPressureParameterTypes(str, Enum):
+class PhysicsPressureModelTypes(_OptionsMixin, str, Enum):
+    FRIABLE = "friable"
+    PATCHY_CEMENT = "patchy_cement"
+
+
+class RegressionPressureParameterTypes(_OptionsMixin, str, Enum):
     VP_VS = "vp_vs"
     K_MU = "k_mu"
 
 
-class ParameterTypes(str, Enum):
+class ParameterTypes(_OptionsMixin, str, Enum):
     VP = "vp"
     VS = "vs"
     K = "k"
@@ -146,7 +159,7 @@ class ParameterTypes(str, Enum):
     POROSITY = "poro"
 
 
-class Sim2SeisRequiredParams(str, Enum):
+class Sim2SeisRequiredParams(_OptionsMixin, str, Enum):
     VP = "vp"
     VS = "vs"
     DENSITY = "density"

--- a/src/fmu/pem/pem_utilities/export_routines.py
+++ b/src/fmu/pem/pem_utilities/export_routines.py
@@ -95,17 +95,18 @@ def save_results(
                     results_dir=full_output_path,
                     time_steps=seis_dates,
                 )
-            export_results_disk(
-                result_props=difference_props,
-                grid=sim_grid,
-                grid_name=grid_name,
-                results_dir=full_output_path,
-                time_steps=difference_date_strs,
-            )
+            if difference_props is not None:
+                export_results_disk(
+                    result_props=difference_props,
+                    grid=sim_grid,
+                    grid_name=grid_name,
+                    results_dir=full_output_path,
+                    time_steps=difference_date_strs,
+                )
     except KeyError:  # warn user that results are not saved
         pem_logger.warning(
             f"{__file__}: no parameter for saving results to disk is found in the "
-            f"config file"
+            "config file"
         )
 
     # 3. Save intermediate results only if specified in the config file

--- a/src/fmu/pem/pem_utilities/export_routines.py
+++ b/src/fmu/pem/pem_utilities/export_routines.py
@@ -1,4 +1,3 @@
-import warnings
 from dataclasses import asdict
 from pathlib import Path
 
@@ -13,7 +12,7 @@ from .pem_class_definitions import (
     PressureProperties,
     SaturatedRockProperties,
 )
-from .utils import _verify_export_inputs, restore_dir
+from .utils import _verify_export_inputs, pem_logger, restore_dir
 
 
 def save_results(
@@ -104,7 +103,7 @@ def save_results(
                 time_steps=difference_date_strs,
             )
     except KeyError:  # warn user that results are not saved
-        warnings.warn(
+        pem_logger.warning(
             f"{__file__}: no parameter for saving results to disk is found in the "
             f"config file"
         )

--- a/src/fmu/pem/pem_utilities/import_routines.py
+++ b/src/fmu/pem/pem_utilities/import_routines.py
@@ -157,7 +157,10 @@ def read_phase_system(unrst_file: Path) -> PhaseSystem:
                     f"of {unrst_file}; expected non-zero subset of 1|2|4."
                 )
             return PhaseSystem(indicator)
-    raise ValueError(f"No INTEHEAD record found in {unrst_file}")
+    raise ValueError(
+        f"No INTEHEAD record found in {unrst_file}. The INTEHEAD information "
+        "is used to indentify the reservoir simulator type and the phase system"
+    )
 
 
 def read_sim_grid_props(
@@ -255,20 +258,16 @@ def import_fractions(
         list: fraction properties
     """
     with restore_dir(root_dir / fraction_path):
-        try:
-            grid_props = [
-                xtgeo.gridproperty_from_file(
-                    file,
-                    name=name,  # type: ignore
-                    grid=grd,  # type: ignore
+        grid_props: list[xtgeo.GridProperty] = []
+        for name, file in zip(fraction_names, fraction_files, strict=True):
+            try:
+                grid_props.append(
+                    xtgeo.gridproperty_from_file(file, name=name, grid=grd)
                 )
-                for name in fraction_names
-                for file in fraction_files
-            ]
-        except ValueError as exc:
-            raise ImportError(
-                f"{__file__}: failed to import volume fractions files {fraction_files}"
-            ) from exc
+            except ValueError as exc:
+                raise ImportError(
+                    f"failed to import volume fraction {name!r} from {file}"
+                ) from exc
     return [grid_prop.values for grid_prop in grid_props]
 
 
@@ -296,8 +295,8 @@ def apply_porosity_adjustment(
     if isinstance(adjustment, ConstantNonNetPorosity):
         if sim_init.ntg is None:
             raise ImportError(
-                "NTG is required for the constant non-net porosity adjustment "
-                "but is not present in the Eclipse INIT file."
+                "NTG parameter is required for the constant non-net porosity "
+                "adjustment but it is not present in the Eclipse INIT file."
             )
         ntg = np.ma.masked_array(sim_init.ntg.data, mask=sim_init.poro.mask)
         _verify_ntg_is_non_binary(ntg)

--- a/src/fmu/pem/pem_utilities/import_routines.py
+++ b/src/fmu/pem/pem_utilities/import_routines.py
@@ -108,7 +108,7 @@ def create_rst_list(
         }
         if "pressure" not in kwargs:
             raise ValueError(
-                f"eclipse simulator restart file is missing PRESSURE for date {date}"
+                f"reservoir simulator restart file is missing PRESSURE for date {date}"
             )
         # Fill any missing phase saturation with zeros sized like pressure.
         pressure = kwargs["pressure"]
@@ -181,8 +181,8 @@ def read_sim_grid_props(
         seis_dates: list of dates for which to read restart properties
 
     Returns:
-        sim_grid: grid definition for eclipse input
-        init_props: object with initial properties of simulation grid
+        sim_grid: grid definition for reservoir simulator input
+        init_props: object with initial properties of simulator grid
         rst_list: list with time-dependent simulation properties
         phase_system: phases present in the simulation (from INTEHEAD item 15)
     """
@@ -194,7 +194,7 @@ def read_sim_grid_props(
 
     phase_system = read_phase_system(rel_dir_sim_files / restart_property_file)
 
-    # TEMP will only be available for eclipse-300
+    # TEMP will only be available for compositional reservoir simulators
     rst_props_names = ["SWAT", "SGAS", "SOIL", "RS", "RV", "PRESSURE", "SALT", "TEMP"]
 
     # Restart properties - set strict to False, False in case RV is not included in
@@ -220,8 +220,9 @@ def read_sim_grid_props(
                 filter_below=True,
             )
 
-    # Formation pressure has unit `bar` in eclipse, but in the PEM models, unit
-    # `Pa` is expected. Perform unit conversion before class objects are populated
+    # Formation pressure has unit `bar` in standard reservoir simulators, but in the
+    # PEM models, unit # `Pa` is expected. Perform unit conversion before class
+    # objects are populated
     for date in seis_dates:
         rst_props["PRESSURE" + "_" + date].values = bar_to_pa(
             rst_props["PRESSURE" + "_" + date].values
@@ -230,7 +231,7 @@ def read_sim_grid_props(
     try:
         rst_list = create_rst_list(rst_props, seis_dates, rst_props_names)
     except (AttributeError, TypeError, KeyError) as e:
-        raise ValueError(f"eclipse simulator restart file is missing parameters: {e}")
+        raise ValueError(f"reservoir simulator restart file is missing parameters: {e}")
 
     for rst in rst_list:
         rst.reconcile_phase_saturations(phase_system)

--- a/src/fmu/pem/pem_utilities/import_routines.py
+++ b/src/fmu/pem/pem_utilities/import_routines.py
@@ -12,7 +12,7 @@ from .pem_config_validation import (
     PorosityAdjustment,
     PreAdjustedPorosityGrid,
 )
-from .utils import bar_to_pa, restore_dir
+from .utils import bar_to_pa, pem_log, pem_log_once, restore_dir
 
 # Eclipse stores the phase indicator in INTEHEAD item 15 (1-indexed) and the
 # simulator program identifier (IPROG) in item 95.
@@ -62,6 +62,16 @@ def read_init_properties(
                     threshold=0,
                     filter_below=True,
                 )
+    else:
+        if "AQUIFERN" in sim_init_props:
+            pem_log(
+                "no negative values for AQUIFERN parameter in INIT file, no cells will "
+                "be masked as aquifer"
+            )
+        else:
+            pem_log(
+                "no AQUIFERN parameter in INIT file, no cells will be masked as aquifer"
+            )
     # Dictionary with lower-case names and the values as masked arrays
     props_dict = {
         sim_init_props[name].name.lower(): sim_init_props[name].values
@@ -159,7 +169,7 @@ def read_phase_system(unrst_file: Path) -> PhaseSystem:
             return PhaseSystem(indicator)
     raise ValueError(
         f"No INTEHEAD record found in {unrst_file}. The INTEHEAD information "
-        "is used to indentify the reservoir simulator type and the phase system"
+        "is used to identify the reservoir simulator type and the phase system"
     )
 
 
@@ -193,6 +203,7 @@ def read_sim_grid_props(
     )
 
     phase_system = read_phase_system(rel_dir_sim_files / restart_property_file)
+    pem_log(f"phase system detected from UNRST: {phase_system.name}")
 
     # TEMP will only be available for compositional reservoir simulators
     rst_props_names = ["SWAT", "SGAS", "SOIL", "RS", "RV", "PRESSURE", "SALT", "TEMP"]
@@ -221,7 +232,7 @@ def read_sim_grid_props(
             )
 
     # Formation pressure has unit `bar` in standard reservoir simulators, but in the
-    # PEM models, unit # `Pa` is expected. Perform unit conversion before class
+    # PEM models, unit `Pa` is expected. Perform unit conversion before class
     # objects are populated
     for date in seis_dates:
         rst_props["PRESSURE" + "_" + date].values = bar_to_pa(
@@ -293,11 +304,13 @@ def apply_porosity_adjustment(
     if isinstance(adjustment, NoPorosityAdjustment):
         return
 
+    initial_average_porosity = np.ma.mean(sim_init.poro)
+
     if isinstance(adjustment, ConstantNonNetPorosity):
         if sim_init.ntg is None:
             raise ImportError(
                 "NTG parameter is required for the constant non-net porosity "
-                "adjustment but it is not present in the Eclipse INIT file."
+                "adjustment but it is not present in the reservoir simulator INIT file."
             )
         ntg = np.ma.masked_array(sim_init.ntg.data, mask=sim_init.poro.mask)
         _verify_ntg_is_non_binary(ntg)
@@ -323,6 +336,11 @@ def apply_porosity_adjustment(
         )
         sim_init.poro = np.ma.masked_array(
             new_poro.values.data, mask=sim_init.poro.mask
+        )
+        pem_log(
+            "porosity adjustment has modified average porosity from "
+            f"{float(initial_average_porosity):.3f} to "
+            f"{float(np.ma.mean(sim_init.poro)):.3f}"
         )
         return
 
@@ -354,7 +372,14 @@ def adjust_mask(
     np.ma.MaskedArray
         grid property with modified mask
     """
+    orig_mask = property.mask
     ind_mask = indicator < threshold if filter_below else indicator > threshold
+    added_mask = np.ma.logical_xor(orig_mask, ind_mask)
+    if np.any(added_mask):
+        pem_log_once(
+            f"adjust_mask: {int(np.sum(added_mask))} aquifer cells "
+            "added to property mask"
+        )
     property.mask = np.logical_or(property.mask, ind_mask)
     return property
 

--- a/src/fmu/pem/pem_utilities/pem_config_validation.py
+++ b/src/fmu/pem/pem_utilities/pem_config_validation.py
@@ -75,7 +75,8 @@ class EclipseFiles(BaseModel):
             return self
         if not self.rel_path_simgrid.exists():
             raise FileNotFoundError(
-                f"simulation grid directory is missing: {self.rel_path_simgrid}"
+                "reservoir simulation grid directory is missing: "
+                f"{self.rel_path_simgrid}"
             )
         for sim_file in [
             self.egrid_file,
@@ -85,7 +86,7 @@ class EclipseFiles(BaseModel):
             full_name = self.rel_path_simgrid / sim_file
             if not full_name.exists():
                 raise FileNotFoundError(
-                    f"Reservoir simulation file is missing: {full_name}"
+                    f"reservoir simulation file is missing: {full_name}"
                 )
         return self
 
@@ -114,13 +115,13 @@ class FractionFiles(BaseModel):
             return self
         if not self.rel_path_fractions.exists():
             raise FileNotFoundError(
-                f"fractions directory is missing: {self.rel_path_fractions}"
+                f"volume fractions directory is missing: {self.rel_path_fractions}"
             )
         for frac_prop in self.fractions_prop_file_names:
             full_fraction_prop = self.rel_path_fractions / frac_prop
             if not full_fraction_prop.exists():
                 raise FileNotFoundError(
-                    f"fraction prop file is missing: {full_fraction_prop}"
+                    f"volume fraction property file is missing: {full_fraction_prop}"
                 )
         return self
 
@@ -163,7 +164,10 @@ class ZoneRegionMatrixParams(BaseModel):
     @classmethod
     def model_check(cls, v: dict, info: ValidationInfo) -> dict:
         if v["model_name"] not in list(RPMType):
-            raise ValueError(f"unknown model: {v['model_name']}")
+            raise ValueError(
+                f"unknown rock physics model: {v['model_name']}\n"
+                f"known rock physics models are: {', '.join(list(RPMType))}"
+            )
         return v
 
 
@@ -221,7 +225,7 @@ class PreAdjustedPorosityGrid(BaseModel):
         full_name = self.rel_path / self.file_name
         if not full_name.exists():
             raise FileNotFoundError(
-                f"pre-adjusted porosity grid file is missing: {full_name}"
+                f"pre-adjusted porosity parameter file is missing: {full_name}"
             )
         return self
 
@@ -349,13 +353,16 @@ class RockMatrixProperties(BaseModel):
                 tmp_max = max(num_array)
                 tmp_num_array = list(range(1, tmp_max + 1))
         if detect_overlaps(fipnum_strings, tmp_num_array):
-            raise ValueError(f"Overlaps in group definitions: {fipnum_strings}")
+            raise ValueError(f"Overlaps in FIPNUM group definitions: {fipnum_strings}")
         return v
 
     @field_validator("cement", mode="before")
     def cement_check(cls, v: str, info: ValidationInfo) -> str:
         if v not in info.data["minerals"]:
-            raise ValueError(f'{__file__}: cement mineral "{v}" not listed in minerals')
+            raise ValueError(
+                f'{__file__}: cement mineral "{v}" not listed in minerals: '
+                f"{', '.join(info.data['minerals'])}"
+            )
         return v
 
     @field_validator("shale_fractions", mode="before")
@@ -365,7 +372,7 @@ class RockMatrixProperties(BaseModel):
             if frac not in info.data["fraction_names"]:
                 raise ValueError(
                     f'{__file__}: shale fraction "{frac}" not listed in volume '
-                    f"fraction names"
+                    f"fraction names: {', '.join(info.data['fraction_names'])}"
                 )
         return v
 
@@ -375,7 +382,7 @@ class RockMatrixProperties(BaseModel):
         if v not in info.data["minerals"]:
             raise ValueError(
                 f'{__file__}: shale fraction mineral "{v}" not listed in fraction '
-                f"minerals"
+                f"minerals: {', '.join(info.data['minerals'])}"
             )
         return v
 
@@ -393,7 +400,10 @@ class RockMatrixProperties(BaseModel):
                     fipnum_group.pressure_sensitivity_model, NoPressureSensitivityModel
                 )
             ):
-                raise ValueError("a model is required when pressure sensitivity is set")
+                raise ValueError(
+                    "a pressure sensitivity model is required when "
+                    "pressure sensitivity is set"
+                )
         return self
 
 
@@ -471,7 +481,7 @@ class Brine(BaseModel):
 
         raise ValueError(
             "sum of chloride percentages "
-            f"({perc_sum}%) differs from 100% by more than 10% "
+            f"({perc_sum}%) differs from 100% by more than 0.1% "
             "in brine parameters"
         )
 
@@ -588,7 +598,7 @@ class PVTZone(BaseModel):
     def check_fluid_type(self) -> Self:
         if self.calculate_condensate and not HAS_PROPRIETARY_ROCK_PHYSICS:
             raise NotImplementedError(
-                "Missing model for condensate, proprietary model required"
+                "missing model for condensate, proprietary model required"
             )
         return self
 
@@ -809,7 +819,10 @@ class PemConfig(BaseModel):
                 os.makedirs(path, exist_ok=True)
             else:
                 if not Path(path).exists():
-                    raise ValueError(f"Directory {path} does not exist")
+                    raise ValueError(
+                        f"PEM paths: Directory {path} does not exist. "
+                        "Please create it before attempting to re-run."
+                    )
         return v
 
     @field_validator("diff_calculation", mode="before")

--- a/src/fmu/pem/pem_utilities/pem_config_validation.py
+++ b/src/fmu/pem/pem_utilities/pem_config_validation.py
@@ -166,7 +166,7 @@ class ZoneRegionMatrixParams(BaseModel):
         if v["model_name"] not in list(RPMType):
             raise ValueError(
                 f"unknown rock physics model: {v['model_name']}\n"
-                f"known rock physics models are: {', '.join(list(RPMType))}"
+                f"known rock physics models are: {RPMType.options()}"
             )
         return v
 

--- a/src/fmu/pem/pem_utilities/pem_config_validation.py
+++ b/src/fmu/pem/pem_utilities/pem_config_validation.py
@@ -48,7 +48,7 @@ from .rpm_models import (
 REGEX_FIPNUM_PVTNUM = r"^(?:\*|(?:\d+(?:-\d+)?)(?:,(?:\d+(?:-\d+)?))*)$"
 
 
-class EclipseFiles(BaseModel):
+class ReservoirSimulatorFiles(BaseModel):
     rel_path_simgrid: Path = Field(
         default=Path("sim2seis/input/pem"),
         description="Relative path of the simulation grid",
@@ -67,7 +67,7 @@ class EclipseFiles(BaseModel):
     )
 
     @model_validator(mode="after")
-    def check_eclipse_files_exist(self, info: ValidationInfo) -> Self:
+    def check_simulator_files_exist(self, info: ValidationInfo) -> Self:
         pre_experiment = (
             info.context.get("pre_experiment", False) if info.context else False
         )
@@ -561,7 +561,7 @@ class PVTZone(BaseModel):
     )
     oil: Oil = Field(
         description="Oil model parameters. Note that GOR (gas-oil ratio) is read from"
-        " eclipse restart file"
+        " reservoir simulator restart file"
     )
     # Note that CO2 does not require a separate definition here, as it's properties only
     # depend on temperature and pressure
@@ -741,7 +741,7 @@ class PemPaths(BaseModel):
     )
     rel_path_simgrid: SkipJsonSchema[Path] = Field(
         default=Path("sim2seis/input/pem"),
-        description="Directory for eclipse simulation grid",
+        description="Directory for reservoir simulator simulation grid",
     )
     rel_path_geogrid: SkipJsonSchema[Path] = Field(
         default=Path("sim2seis/input/pem"),
@@ -770,7 +770,7 @@ class PemConfig(BaseModel):
         description="Default path settings exist, it is possible to override them, "
         "mostly relevant for input paths",
     )
-    eclipse_files: EclipseFiles
+    simulator_files: ReservoirSimulatorFiles
     rock_matrix: RockMatrixProperties = Field(
         description="Settings related to effective mineral properties and rock "
         "physics model",

--- a/src/fmu/pem/pem_utilities/rock_physics_adapter.py
+++ b/src/fmu/pem/pem_utilities/rock_physics_adapter.py
@@ -153,7 +153,7 @@ def condensate_properties(
     if not HAS_PROPRIETARY_ROCK_PHYSICS:
         raise RuntimeError(
             "Condensate property calculation is not possible without the proprietary "
-            "rock physics package installed."
+            "rock physics package installed or an alternative implementation."
         )
 
     vp_c, rho_c, bulk_c = internal_condensate_properties(

--- a/src/fmu/pem/pem_utilities/update_grid.py
+++ b/src/fmu/pem/pem_utilities/update_grid.py
@@ -1,8 +1,9 @@
-import warnings
 from dataclasses import asdict
 
 import numpy as np
 import xtgeo
+
+from fmu.pem.pem_utilities.utils import pem_logger
 
 from .pem_class_definitions import SaturatedRockProperties
 
@@ -42,7 +43,7 @@ def update_inactive_grid_cells(
     init_mask = np.logical_not(init_mask)
 
     if not np.all(init_mask == grid.actnum_array.astype(bool)):
-        warnings.warn(
+        pem_logger.warning(
             f"There are undefined values in PEM results: "
             f"{np.sum(np.logical_xor(init_mask, grid.actnum_array.astype(bool)))} "
             f"cells are added to the model's inactive cells. \nPlease investigate the "

--- a/src/fmu/pem/pem_utilities/utils.py
+++ b/src/fmu/pem/pem_utilities/utils.py
@@ -93,7 +93,10 @@ def filter_and_one_dim(
             - filtered arrays: 1D arrays containing the unmasked values from each arg
     """
     if not np.all([isinstance(arg, np.ma.MaskedArray) for arg in args]):
-        raise ValueError(f"{__file__}: all inputs should be numpy masked arrays")
+        raise ValueError(
+            f"{__file__}: all inputs should be numpy masked arrays"
+            f"Inputs are: {', '.join([type(m) for m in args])}"
+        )
 
     # Combine masks
     mask = args[0].mask
@@ -220,7 +223,10 @@ def get_shale_fraction(
             idx = fraction_names.index(shale_name)
             sh_list.append(vol_fractions[idx])
         except ValueError:
-            raise ValueError(f"unknown shale fraction: {shale_name}")
+            raise ValueError(
+                f"unknown shale fraction: {shale_name}\n"
+                f"known fraction names are: {', '.join(fraction_names)}"
+            )
 
     # Note that masked elements are set to 0 internally.
     return np.ma.sum(sh_list, axis=0)
@@ -270,7 +276,7 @@ def update_dict_list(base_list: list[dict], add_list: list[dict]) -> list[dict]:
 
 def _verify_update_inputs(base, add_list):
     if not isinstance(base, list) and isinstance(add_list, list):
-        raise TypeError(f"{__file__}: inputs are not lists")
+        raise TypeError("update dict from list: inputs are not lists")
     if not len(base) == len(add_list):
         raise ValueError(
             f"{__file__}: mismatch in list lengths: base list: {len(base)} vs. added "

--- a/src/fmu/pem/pem_utilities/utils.py
+++ b/src/fmu/pem/pem_utilities/utils.py
@@ -1,4 +1,7 @@
+import logging
 import os
+import sys
+import time
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Generator
@@ -312,3 +315,78 @@ def convert_pressures_list_to_pa(
     press_bar: list[PressureProperties],
 ) -> list[PressureProperties]:
     return [convert_single_pressure_to_pa(pres) for pres in press_bar]
+
+
+def _format_elapsed(seconds: float) -> str:
+    minutes, secs = divmod(seconds, 60)
+    return f"{int(minutes)} min {secs:5.2f} sec"
+
+
+_run_start_time: float | None = None
+
+
+class _ElapsedFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        level = "" if record.levelno == logging.INFO else f" {record.levelname}"
+        if _run_start_time is None:
+            return f"PEM{level}: {record.getMessage()}"
+        elapsed = time.monotonic() - _run_start_time
+        return f"PEM [{_format_elapsed(elapsed)}]{level}: {record.getMessage()}"
+
+
+_PEM_FORMATTER = _ElapsedFormatter()
+
+pem_logger = logging.getLogger("fmu.pem")
+pem_logger.setLevel(logging.WARNING)
+pem_logger.propagate = False
+
+_stderr_handler = logging.StreamHandler(sys.stderr)
+_stderr_handler.setFormatter(_PEM_FORMATTER)
+_stderr_handler.setLevel(logging.WARNING)
+pem_logger.addHandler(_stderr_handler)
+
+_stdout_handler: logging.Handler | None = None
+
+
+def start_pem_run_log(level: int = logging.INFO) -> None:
+    """Activate verbose PEM run logging.
+
+    Anchors the elapsed-time origin and attaches a stdout handler for
+    records below ``WARNING``. ``WARNING`` and above always reach stderr,
+    independent of this call. Repeated calls are no-ops; call
+    :func:`stop_pem_run_log` first to re-anchor.
+    """
+    global _run_start_time, _stdout_handler
+    if _run_start_time is not None:
+        return
+    _run_start_time = time.monotonic()
+
+    _stdout_handler = logging.StreamHandler(sys.stdout)
+    _stdout_handler.setFormatter(_PEM_FORMATTER)
+    _stdout_handler.addFilter(lambda r: r.levelno < logging.WARNING)
+
+    pem_logger.setLevel(level)
+    pem_logger.addHandler(_stdout_handler)
+
+
+def stop_pem_run_log() -> None:
+    """Deactivate verbose PEM run logging.
+
+    Detaches the stdout handler and resets the elapsed-time origin. The
+    stderr handler for ``WARNING`` and above remains attached.
+    """
+    global _run_start_time, _stdout_handler
+    if _stdout_handler is not None:
+        pem_logger.removeHandler(_stdout_handler)
+        _stdout_handler = None
+    pem_logger.setLevel(logging.WARNING)
+    _run_start_time = None
+
+
+def pem_log(message: str, level: int = logging.INFO) -> None:
+    """Emit ``message`` on the PEM logger at ``level`` (default ``INFO``).
+
+    ``INFO``/``DEBUG`` go to stdout only while :func:`start_pem_run_log` is
+    active. ``WARNING``/``ERROR``/``CRITICAL`` always go to stderr.
+    """
+    pem_logger.log(level, message)

--- a/src/fmu/pem/pem_utilities/utils.py
+++ b/src/fmu/pem/pem_utilities/utils.py
@@ -94,8 +94,8 @@ def filter_and_one_dim(
     """
     if not np.all([isinstance(arg, np.ma.MaskedArray) for arg in args]):
         raise ValueError(
-            f"{__file__}: all inputs should be numpy masked arrays"
-            f"Inputs are: {', '.join([type(m) for m in args])}"
+            "all inputs should be numpy masked arrays; "
+            f"got: {', '.join(type(m).__name__ for m in args)}"
         )
 
     # Combine masks
@@ -275,7 +275,7 @@ def update_dict_list(base_list: list[dict], add_list: list[dict]) -> list[dict]:
 
 
 def _verify_update_inputs(base, add_list):
-    if not isinstance(base, list) and isinstance(add_list, list):
+    if not (isinstance(base, list) and isinstance(add_list, list)):
         raise TypeError("update dict from list: inputs are not lists")
     if not len(base) == len(add_list):
         raise ValueError(
@@ -371,7 +371,7 @@ def start_pem_run_log(level: int = logging.INFO) -> None:
     _stdout_handler.setFormatter(_PEM_FORMATTER)
     _stdout_handler.addFilter(lambda r: r.levelno < logging.WARNING)
 
-    pem_logger.setLevel(level)
+    pem_logger.setLevel(min(level, logging.WARNING))
     pem_logger.addHandler(_stdout_handler)
 
 
@@ -387,6 +387,7 @@ def stop_pem_run_log() -> None:
         _stdout_handler = None
     pem_logger.setLevel(logging.WARNING)
     _run_start_time = None
+    _logged_once.clear()
 
 
 def pem_log(message: str, level: int = logging.INFO) -> None:
@@ -395,4 +396,19 @@ def pem_log(message: str, level: int = logging.INFO) -> None:
     ``INFO``/``DEBUG`` go to stdout only while :func:`start_pem_run_log` is
     active. ``WARNING``/``ERROR``/``CRITICAL`` always go to stderr.
     """
+    pem_logger.log(level, message)
+
+
+_logged_once: set[str] = set()
+
+
+def pem_log_once(message: str, level: int = logging.INFO) -> None:
+    """Emit ``message`` at most once per run (deduplicated by message text).
+
+    The seen-set is cleared by :func:`stop_pem_run_log`, so a fresh run
+    starts with an empty history.
+    """
+    if message in _logged_once:
+        return
+    _logged_once.add(message)
     pem_logger.log(level, message)

--- a/src/fmu/pem/run_pem.py
+++ b/src/fmu/pem/run_pem.py
@@ -1,13 +1,12 @@
-import time
 from pathlib import Path
 
 from fmu.pem import pem_functions as pem_fcns
 from fmu.pem import pem_utilities as pem_utils
-
-
-def _format_elapsed(seconds: float) -> str:
-    minutes, secs = divmod(seconds, 60)
-    return f"{int(minutes)} min {secs:5.2f} sec"
+from fmu.pem.pem_utilities.utils import (
+    pem_log,
+    start_pem_run_log,
+    stop_pem_run_log,
+)
 
 
 def pem_fcn(
@@ -20,131 +19,125 @@ def pem_fcn(
     yaml-file control the selections made in the PEM.
 
     """
-    start_time = time.monotonic()
-
-    def _log(message: str) -> None:
-        elapsed = time.monotonic() - start_time
-        print(f"PEM [{_format_elapsed(elapsed)}]: {message}")
-
     if verbose:
-        _log("process started")
-    with pem_utils.restore_dir(run_dir):
-        # Import Eclipse simulation grid - INIT and RESTART
-        sim_grid, constant_props, time_step_props, _phase_system = (
-            pem_utils.read_sim_grid_props(
-                rel_dir_sim_files=config.eclipse_files.rel_path_simgrid,
-                egrid_file=config.eclipse_files.egrid_file,
-                init_property_file=config.eclipse_files.init_property_file,
-                restart_property_file=config.eclipse_files.restart_property_file,
-                seis_dates=config.global_params.mod_dates,
-                fipnum_name=config.alternative_fipnum_name,
+        start_pem_run_log()
+    try:
+        pem_log("process started")
+        with pem_utils.restore_dir(run_dir):
+            # Import Eclipse simulation grid - INIT and RESTART
+            sim_grid, constant_props, time_step_props, _phase_system = (
+                pem_utils.read_sim_grid_props(
+                    rel_dir_sim_files=config.eclipse_files.rel_path_simgrid,
+                    egrid_file=config.eclipse_files.egrid_file,
+                    init_property_file=config.eclipse_files.init_property_file,
+                    restart_property_file=config.eclipse_files.restart_property_file,
+                    seis_dates=config.global_params.mod_dates,
+                    fipnum_name=config.alternative_fipnum_name,
+                )
             )
-        )
-        if verbose:
-            _log("simgrid, init and restart properties read")
+            pem_log("simgrid, init and restart properties read")
 
-        # Optionally adjust PORO for non-binary NTG (constant non-net porosity
-        # or a pre-adjusted grid parameter file).
-        pem_utils.apply_porosity_adjustment(
-            adjustment=config.rock_matrix.porosity_adjustment,
-            sim_init=constant_props,
-            sim_grid=sim_grid,
-            root_dir=run_dir,
-        )
+            # Optionally adjust PORO for non-binary NTG (constant non-net porosity
+            # or a pre-adjusted grid parameter file).
+            pem_utils.apply_porosity_adjustment(
+                adjustment=config.rock_matrix.porosity_adjustment,
+                sim_init=constant_props,
+                sim_grid=sim_grid,
+                root_dir=run_dir,
+            )
 
-        # Calculate rock properties - fluids and minerals
-        # Effective mineral (matrix) properties - one set valid for all time-steps
-        vsh, matrix_properties = pem_fcns.effective_mineral_properties(
-            root_dir=run_dir,
-            matrix=config.rock_matrix,
-            sim_init=constant_props,
-            sim_grid=sim_grid,
-        )
-        # VSH is exported with other constant results, add it to the constant properties
-        constant_props.vsh_pem = vsh
-        if verbose:
-            _log("mineral properties estimated")
+            # Calculate rock properties - fluids and minerals
+            # Effective mineral (matrix) properties - one set valid for all time-steps
+            vsh, matrix_properties = pem_fcns.effective_mineral_properties(
+                root_dir=run_dir,
+                matrix=config.rock_matrix,
+                sim_init=constant_props,
+                sim_grid=sim_grid,
+            )
+            # VSH is exported with other constant results, add it to the constant
+            # properties
+            constant_props.vsh_pem = vsh
+            pem_log("mineral properties estimated")
 
-        # Fluid properties calculated for all time-steps
-        fluid_properties, below_bp_grids = pem_fcns.effective_fluid_properties_zoned(
-            restart_props=time_step_props,
-            fluids=config.fluids,
-            pvtnum=constant_props.pvtnum,
-        )
-        if verbose:
-            _log("fluid properties estimated")
+            # Fluid properties calculated for all time-steps
+            fluid_properties, below_bp_grids = (
+                pem_fcns.effective_fluid_properties_zoned(
+                    restart_props=time_step_props,
+                    fluids=config.fluids,
+                    pvtnum=constant_props.pvtnum,
+                )
+            )
+            pem_log("fluid properties estimated")
 
-        # Estimate effective pressure
-        eff_pres = pem_fcns.estimate_pressure(
-            rock_matrix=config.rock_matrix,
-            overburden_pressure=config.pressure,
-            sim_init=constant_props,
-            sim_rst=time_step_props,
-            matrix_props=matrix_properties,
-            fluid_props=fluid_properties,
-            sim_dates=config.global_params.mod_dates,
-            fipnum=constant_props.fipnum,
-        )
-        if verbose:
-            _log("effective pressure estimated")
+            # Estimate effective pressure
+            eff_pres = pem_fcns.estimate_pressure(
+                rock_matrix=config.rock_matrix,
+                overburden_pressure=config.pressure,
+                sim_init=constant_props,
+                sim_rst=time_step_props,
+                matrix_props=matrix_properties,
+                fluid_props=fluid_properties,
+                sim_dates=config.global_params.mod_dates,
+                fipnum=constant_props.fipnum,
+            )
+            pem_log("effective pressure estimated")
 
-        # Estimate saturated rock properties
-        sat_rock_props, dry_rock = pem_fcns.estimate_saturated_rock(
-            rock_matrix=config.rock_matrix,
-            sim_init=constant_props,
-            press_props=eff_pres,
-            matrix_props=matrix_properties,
-            fluid_props=fluid_properties,
-            model_directory=config.paths.rel_path_pem,
-            fipnum_param=constant_props.fipnum,
-        )
-        if verbose:
-            _log("dry and saturated rock properties estimated")
+            # Estimate saturated rock properties
+            sat_rock_props, dry_rock = pem_fcns.estimate_saturated_rock(
+                rock_matrix=config.rock_matrix,
+                sim_init=constant_props,
+                press_props=eff_pres,
+                matrix_props=matrix_properties,
+                fluid_props=fluid_properties,
+                model_directory=config.paths.rel_path_pem,
+                fipnum_param=constant_props.fipnum,
+            )
+            pem_log("dry and saturated rock properties estimated")
 
-        # Delta and cumulative time estimates (only TWT properties are kept)
-        sum_delta_time = pem_utils.delta_cumsum_time.estimate_sum_delta_time(
-            constant_props=constant_props,
-            sat_rock_props=sat_rock_props,
-        )
+            # Delta and cumulative time estimates (only TWT properties are kept)
+            sum_delta_time = pem_utils.delta_cumsum_time.estimate_sum_delta_time(
+                constant_props=constant_props,
+                sat_rock_props=sat_rock_props,
+            )
 
-        # Calculate difference properties. Possible properties are all that vary with
-        # time
-        diff_props, diff_date_strs = pem_utils.calculate_diff_properties(
-            props=[time_step_props, eff_pres, sat_rock_props, sum_delta_time],
-            diff_dates=config.global_params.mod_diffdates,
-            seis_dates=config.global_params.mod_dates,
-            diff_calculation=config.diff_calculation,
-        )
-        if verbose:
-            _log("differential properties estimated")
+            # Calculate difference properties. Possible properties are all that vary
+            # with time
+            diff_props, diff_date_strs = pem_utils.calculate_diff_properties(
+                props=[time_step_props, eff_pres, sat_rock_props, sum_delta_time],
+                diff_dates=config.global_params.mod_diffdates,
+                seis_dates=config.global_params.mod_dates,
+                diff_calculation=config.diff_calculation,
+            )
+            pem_log("differential properties estimated")
 
-        # As a precaution, update the grid mask for inactive cells, based on the
-        # saturated rock properties
-        sim_grid = pem_utils.update_inactive_grid_cells(
-            grid=sim_grid,
-            props=sat_rock_props,
-        )
+            # As a precaution, update the grid mask for inactive cells, based on the
+            # saturated rock properties
+            sim_grid = pem_utils.update_inactive_grid_cells(
+                grid=sim_grid,
+                props=sat_rock_props,
+            )
 
-        # Save results to disk according to settings in the PEM config
-        pem_utils.save_results(
-            config_dir=run_dir,
-            sim_grid=sim_grid,
-            grid_name=config.global_params.grid_model,
-            seis_dates=config.global_params.mod_dates,
-            save_to_disk=config.results.save_results_to_disk,
-            save_intermediate=config.results.save_intermediate_results,
-            mandatory_path=config.paths.rel_path_mandatory_output,
-            pem_output_path=config.paths.rel_path_output,
-            eff_pres_props=eff_pres,
-            sat_rock_props=sat_rock_props,
-            difference_props=diff_props,
-            difference_date_strs=diff_date_strs,
-            matrix_props=matrix_properties,
-            fluid_props=fluid_properties,
-            bubble_point_grids=below_bp_grids,
-            dry_rock_props=dry_rock,
-        )
-        if verbose:
-            _log("saved results, process finished")
+            # Save results to disk according to settings in the PEM config
+            pem_utils.save_results(
+                config_dir=run_dir,
+                sim_grid=sim_grid,
+                grid_name=config.global_params.grid_model,
+                seis_dates=config.global_params.mod_dates,
+                save_to_disk=config.results.save_results_to_disk,
+                save_intermediate=config.results.save_intermediate_results,
+                mandatory_path=config.paths.rel_path_mandatory_output,
+                pem_output_path=config.paths.rel_path_output,
+                eff_pres_props=eff_pres,
+                sat_rock_props=sat_rock_props,
+                difference_props=diff_props,
+                difference_date_strs=diff_date_strs,
+                matrix_props=matrix_properties,
+                fluid_props=fluid_properties,
+                bubble_point_grids=below_bp_grids,
+                dry_rock_props=dry_rock,
+            )
+            pem_log("saved results, process finished")
+    finally:
+        stop_pem_run_log()
 
     return

--- a/src/fmu/pem/run_pem.py
+++ b/src/fmu/pem/run_pem.py
@@ -27,18 +27,19 @@ def pem_fcn(
             # Import Eclipse simulation grid - INIT and RESTART
             sim_grid, constant_props, time_step_props, _phase_system = (
                 pem_utils.read_sim_grid_props(
-                    rel_dir_sim_files=config.eclipse_files.rel_path_simgrid,
-                    egrid_file=config.eclipse_files.egrid_file,
-                    init_property_file=config.eclipse_files.init_property_file,
-                    restart_property_file=config.eclipse_files.restart_property_file,
+                    rel_dir_sim_files=config.simulator_files.rel_path_simgrid,
+                    egrid_file=config.simulator_files.egrid_file,
+                    init_property_file=config.simulator_files.init_property_file,
+                    restart_property_file=config.simulator_files.restart_property_file,
                     seis_dates=config.global_params.mod_dates,
                     fipnum_name=config.alternative_fipnum_name,
                 )
             )
-            pem_log("simgrid, init and restart properties read")
+            pem_log("reservoir simulator grid, init and restart properties read")
 
             # Optionally adjust PORO for non-binary NTG (constant non-net porosity
-            # or a pre-adjusted grid parameter file).
+            # or a pre-adjusted grid parameter file). Log message is produced during
+            # adjustment
             pem_utils.apply_porosity_adjustment(
                 adjustment=config.rock_matrix.porosity_adjustment,
                 sim_init=constant_props,
@@ -59,7 +60,7 @@ def pem_fcn(
             constant_props.vsh_pem = vsh
             pem_log("mineral properties estimated")
 
-            # Fluid properties calculated for all time-steps
+            # Fluid properties are calculated for all time-steps
             fluid_properties, below_bp_grids = (
                 pem_fcns.effective_fluid_properties_zoned(
                     restart_props=time_step_props,
@@ -102,13 +103,17 @@ def pem_fcn(
 
             # Calculate difference properties. Possible properties are all that vary
             # with time
-            diff_props, diff_date_strs = pem_utils.calculate_diff_properties(
-                props=[time_step_props, eff_pres, sat_rock_props, sum_delta_time],
-                diff_dates=config.global_params.mod_diffdates,
-                seis_dates=config.global_params.mod_dates,
-                diff_calculation=config.diff_calculation,
-            )
-            pem_log("differential properties estimated")
+            if config.diff_calculation:
+                diff_props, diff_date_strs = pem_utils.calculate_diff_properties(
+                    props=[time_step_props, eff_pres, sat_rock_props, sum_delta_time],
+                    diff_dates=config.global_params.mod_diffdates,
+                    seis_dates=config.global_params.mod_dates,
+                    diff_calculation=config.diff_calculation,
+                )
+                pem_log("differential properties estimated")
+            else:
+                diff_props = None
+                diff_date_strs = None
 
             # As a precaution, update the grid mask for inactive cells, based on the
             # saturated rock properties

--- a/tests/data/sim2seis/model/pem_config_condensate.yml
+++ b/tests/data/sim2seis/model/pem_config_condensate.yml
@@ -9,7 +9,7 @@ paths:
 #  rel_path_geogrid: share/results/grids
 
 simulator_files:
-  # Import Eclipse simulation grid - INIT and RESTART
+  # Import reservoir simulation grid - INIT and RESTART
   egrid_file: ECLIPSE.EGRID
   init_property_file: ECLIPSE.INIT
   restart_property_file: ECLIPSE.UNRST

--- a/tests/data/sim2seis/model/pem_config_condensate.yml
+++ b/tests/data/sim2seis/model/pem_config_condensate.yml
@@ -8,7 +8,7 @@ paths:
 #  rel_path_simgrid: sim2seis/input/pem
 #  rel_path_geogrid: share/results/grids
 
-eclipse_files:
+simulator_files:
   # Import Eclipse simulation grid - INIT and RESTART
   egrid_file: ECLIPSE.EGRID
   init_property_file: ECLIPSE.INIT

--- a/tests/data/sim2seis/model/pem_config_condensate_multi.yml
+++ b/tests/data/sim2seis/model/pem_config_condensate_multi.yml
@@ -9,7 +9,7 @@ paths:
 #  rel_path_geogrid: share/results/grids
 
 simulator_files:
-  # Import Eclipse simulation grid - INIT and RESTART
+  # Import reservoir simulation grid - INIT and RESTART
   egrid_file: ECLIPSE.EGRID
   init_property_file: ECLIPSE.INIT
   restart_property_file: ECLIPSE.UNRST

--- a/tests/data/sim2seis/model/pem_config_condensate_multi.yml
+++ b/tests/data/sim2seis/model/pem_config_condensate_multi.yml
@@ -8,7 +8,7 @@ paths:
 #  rel_path_simgrid: sim2seis/input/pem
 #  rel_path_geogrid: share/results/grids
 
-eclipse_files:
+simulator_files:
   # Import Eclipse simulation grid - INIT and RESTART
   egrid_file: ECLIPSE.EGRID
   init_property_file: ECLIPSE.INIT

--- a/tests/data/sim2seis/model/pem_config_no_condensate.yml
+++ b/tests/data/sim2seis/model/pem_config_no_condensate.yml
@@ -9,7 +9,7 @@ paths:
 #  rel_path_geogrid: share/results/grids
 
 simulator_files:
-  # Import Eclipse simulation grid - INIT and RESTART
+  # Import reservoir simulation grid - INIT and RESTART
   egrid_file: ECLIPSE.EGRID
   init_property_file: ECLIPSE.INIT
   restart_property_file: ECLIPSE.UNRST

--- a/tests/data/sim2seis/model/pem_config_no_condensate.yml
+++ b/tests/data/sim2seis/model/pem_config_no_condensate.yml
@@ -8,7 +8,7 @@ paths:
 #  rel_path_simgrid: sim2seis/input/pem
 #  rel_path_geogrid: share/results/grids
 
-eclipse_files:
+simulator_files:
   # Import Eclipse simulation grid - INIT and RESTART
   egrid_file: ECLIPSE.EGRID
   init_property_file: ECLIPSE.INIT

--- a/tests/test_fluids.py
+++ b/tests/test_fluids.py
@@ -293,14 +293,26 @@ def test_above_bubble_point_succeeds(sim_props_high_pressure, pvtnum_grid):
     assert np.all(res.bulk_modulus > 0.0)
 
 
-def test_below_bubble_point_with_z_factor(sim_props_low_pressure, pvtnum_grid):
+@pytest.mark.filterwarnings(
+    "ignore:divide by zero encountered in power:RuntimeWarning",
+    "ignore:divide by zero encountered in reciprocal:RuntimeWarning",
+)
+def test_below_bubble_point_with_z_factor(
+    sim_props_low_pressure, pvtnum_grid, caplog, monkeypatch
+):
     """Test that setting gas_z_factor != 1.0 allows operation below bubble point"""
+    from fmu.pem.pem_utilities.utils import pem_logger
+
+    monkeypatch.setattr(pem_logger, "propagate", True)
+    caplog.set_level("WARNING", logger="fmu.pem")
+
     fluids_with_z = cast(Fluids, StubFluids(gas_z_factor=0.95))
-    # Should not raise an error, and should issue a warning instead
-    with pytest.warns(UserWarning, match="Detected pressure below bubble point"):
-        res, bp = effective_fluid_properties_zoned(
-            sim_props_low_pressure, fluids_with_z, pvtnum_grid
-        )
+    res, bp = effective_fluid_properties_zoned(
+        sim_props_low_pressure, fluids_with_z, pvtnum_grid
+    )
+    assert any(
+        "Detected pressure below bubble point" in r.getMessage() for r in caplog.records
+    )
     assert isinstance(res[0], EffectiveFluidProperties)
     assert res[0].density.shape == (3,)
     assert np.all(res[0].bulk_modulus > 0.0)

--- a/tests/test_pem.py
+++ b/tests/test_pem.py
@@ -43,6 +43,7 @@ def test_pem_fcn(data_dir, monkeypatch):
     pem_fcn(
         config=conf,
         run_dir=run_dir,
+        verbose=True,
     )
 
 

--- a/tests/test_porosity_adjustment.py
+++ b/tests/test_porosity_adjustment.py
@@ -222,7 +222,7 @@ def test_constant_non_net_adjustment_raises_when_ntg_absent(
     sim_init, sim_grid, tmp_path
 ):
     assert sim_init.ntg is None
-    with pytest.raises(ImportError, match="NTG is required"):
+    with pytest.raises(ImportError, match="NTG parameter is required"):
         apply_porosity_adjustment(
             adjustment=ConstantNonNetPorosity(non_net_porosity=0.05),
             sim_init=sim_init,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -124,7 +124,15 @@ def test_verify_mineral_inputs():
         )
 
 
-def test_normalize_mineral_fractions():
+def test_normalize_mineral_fractions(caplog, monkeypatch):
+    from fmu.pem.pem_utilities.utils import pem_logger
+
+    monkeypatch.setattr(pem_logger, "propagate", True)
+    caplog.set_level("WARNING", logger="fmu.pem")
+
+    def _warned(substring: str) -> bool:
+        return any(substring in r.getMessage() for r in caplog.records)
+
     # Basic case - fractions sum to less than 1
     names = ["shale"]
     fracs = [np.ma.array([0.63])]
@@ -138,23 +146,25 @@ def test_normalize_mineral_fractions():
     assert_array_almost_equal(np.ma.sum(result_fracs), 1.0)
 
     # Test clipping of negative values
+    caplog.clear()
     names = ["shale"]
     fracs = [np.ma.array([-0.1])]
-    with pytest.warns(UserWarning, match="fraction shale has values outside of range"):
-        result_names, result_fracs = normalize_mineral_fractions(
-            names, fracs, "quartz", por, False
-        )
+    result_names, result_fracs = normalize_mineral_fractions(
+        names, fracs, "quartz", por, False
+    )
+    assert _warned("fraction shale has values outside of range")
     assert_array_almost_equal(result_fracs[0], 0.0)
     assert_array_almost_equal(result_fracs[1], 1.0)
     assert_array_almost_equal(np.ma.sum(result_fracs), 1.0)
 
     # Test clipping of values > 1
+    caplog.clear()
     names = ["shale"]
     fracs = [np.ma.array([1.2])]
-    with pytest.warns(UserWarning, match="fraction shale has values outside of range"):
-        result_names, result_fracs = normalize_mineral_fractions(
-            names, fracs, "quartz", por, True
-        )
+    result_names, result_fracs = normalize_mineral_fractions(
+        names, fracs, "quartz", por, True
+    )
+    assert _warned("fraction shale has values outside of range")
     assert_array_almost_equal(result_fracs[0], 1.0)
     # No complement fraction should be added when the main fraction is 1.0
     assert len(result_fracs) == 1
@@ -162,12 +172,13 @@ def test_normalize_mineral_fractions():
     assert_array_almost_equal(np.ma.sum(result_fracs), 1.0)
 
     # Test scaling when sum > 1
+    caplog.clear()
     names = ["shale", "calcite"]
     fracs = [np.ma.array([0.7]), np.ma.array([0.6])]
-    with pytest.warns(UserWarning, match="sum of fractions has values above limit"):
-        result_names, result_fracs = normalize_mineral_fractions(
-            names, fracs, "quartz", por, True
-        )
+    result_names, result_fracs = normalize_mineral_fractions(
+        names, fracs, "quartz", por, True
+    )
+    assert _warned("sum of fractions exceeds limit by maximum")
     assert_array_almost_equal(np.ma.sum(result_fracs), 1.0)
     assert_array_almost_equal(result_fracs[0] / result_fracs[1], 0.7 / 0.6)
 


### PR DESCRIPTION
## Problem

Diagnostics in `fmu-pem` were inconsistent and hard to follow during ERT runs:

- Progress was emitted via ad-hoc `print` calls in `run_pem.py`, with no
  elapsed-time context and no way to suppress or capture it.
- Warnings were routed through `warnings.warn(..., UserWarning)`, which
  could not be filtered alongside other PEM diagnostics and bypassed any
  logging configuration.
- Error messages referenced "Eclipse" in places where OPM Flow and
  Eclipse 300 are equally valid, and the option strings listed in
  `ValueError` messages had to be hand-maintained per enum class.
- Several tests relied on `pytest.warns(UserWarning, …)` and would silently
  break the moment a warning site was migrated to the new logger; one
  helper error message was joining `type` objects directly, producing
  a `TypeError` instead of the intended `ValueError`.

## Solution

Fixes #147 

Introduce a single `fmu.pem` logger with stdout/stderr level separation
and an elapsed-time formatter, migrate warning sites to it, and tighten
existing error messages.

- `pem_logger` is created at module import in
  `pem_utilities/utils.py` (`logging.getLogger("fmu.pem")`, `propagate=False`).
  - `WARNING` and above are always emitted to stderr via an always-on
    handler.
  - `start_pem_run_log()` / `stop_pem_run_log()` toggle a stdout handler
    for `INFO`/`DEBUG`, anchoring the elapsed-time origin used by
    `_ElapsedFormatter`. Repeated `start` calls are no-ops.
  - `pem_log(msg, level=INFO)` is the convenience wrapper for progress
    markers; `pem_log_once(msg, level=INFO)` deduplicates by message text
    and is cleared on `stop_pem_run_log()`.
- `run_pem.py` now opens with `start_pem_run_log()` (gated by `verbose`),
  emits status between phases via `pem_log`, and stops the logger in
  `finally`.
- All `warnings.warn(..., UserWarning)` sites in PEM code have been
  converted to `pem_logger.warning(...)`; the obsolete `from warnings
  import warn` imports were removed where they became unused.
- `enum_defs.py` got an `_OptionsMixin` exposing
  `<EnumClass>.options() -> str`, used in error messages so the listed
  values can never drift from the enum definition.
- Identifier and message cleanup: references to "Eclipse" replaced with
  generic "reservoir simulator" wording where Eclipse 300 / OPM Flow
  apply equally; misleading `ValueError` strings tightened; diff
  properties are now optional in the PEM config.
- `filter_and_one_dim` error message no longer crashes with
  `TypeError: sequence item 0: expected str instance, type found`
  (was joining `type` objects directly).

## Changes

- **feat: add a logging system to `fmu-pem` (7267ae3)** — introduce
  `pem_logger`, `pem_log`, `pem_log_once`, `start_pem_run_log`,
  `stop_pem_run_log`, and the `_ElapsedFormatter` in
  `pem_utilities/utils.py`; wire `run_pem.py` to use them.
- **fix: use pem_logger for warnings (eba34e4)** — replace
  `warnings.warn(..., UserWarning)` calls in `mineral_properties.py` and
  `fluid_properties.py` with `pem_logger.warning(...)`; remove unused
  `warn` imports.
- **feat: add `.options` method to enum defs (5c392ad)** — add
  `_OptionsMixin` to `enum_defs.py` and apply it to all `(str, Enum)`
  classes (`PhaseSystem` IntFlag left as-is); use `Enum.options()` in
  error messages where applicable.
- **chore: improve existing error messages (930e93a)** — tighten
  `ValueError`/`ImportError` strings across the codebase; fix the
  `filter_and_one_dim` `type`-join bug in `utils.py`; fix
  `pem_logger.warnings` → `pem_logger.warning` typo in
  `fluid_properties.py` and `update_grid.py`.
- **chore: change names referring to Eclipse to generic reservoir
  simulator; fix: make diff properties optional (303d39b)** — rename
  Eclipse-specific identifiers/messages to neutral terminology where
  Eclipse 300/OPM Flow also apply; relax pydantic schema so `diff`
  properties are optional.
- **docs: improve error messages using pem_logger (4e3dc58)** — update
  docstrings and inline comments to reflect the new logging behaviour.

## Tests

- `tests/test_fluids.py::test_below_bubble_point_with_z_factor` — switched
  from `pytest.warns(UserWarning, …)` to `caplog` (with
  `monkeypatch.setattr(pem_logger, "propagate", True)` so `caplog` can
  see records on the non-propagating logger). Added narrow
  `@pytest.mark.filterwarnings(…)` to suppress two recurring third-party
  `RuntimeWarning`s from `rock_physics.fluid_models.gas_model.gas_viscosity`.
- `tests/test_utils.py::test_normalize_mineral_fractions` — same
  `pytest.warns` → `caplog` migration.
- `tests/test_porosity_adjustment.py::test_constant_non_net_adjustment_raises_when_ntg_absent`
  — regex tightened to match the new "NTG parameter is required" message.
- `tests/test_pem.py` — minor update aligned with the new logging hooks.