### PR TITLE
fix: remove `ert` pre-experiment validation

### DIFF
--- a/documentation/docs/remote-debugging.md
+++ b/documentation/docs/remote-debugging.md
@@ -12,12 +12,12 @@ debug it because the process is started by ERT, not by VS Code. Instead, the
 process opens a debug *server*, blocks until VS Code connects to it, and only
 then continues execution.
 
-The same helper is reused for the pre-experiment validation phase, which runs
-in a separate Python process from the per-realisation forward model step. This
-means **two attach sessions are needed for one ERT experiment** if you want to
-debug both phases. If the process is not stopped during the pre-experiment phase,
-a single break is needed. **NB! Make sure that debugging is not attempted in ensemble
-runs with several realizations**.
+`wait_for_debugger()` may be called more than once — either at several points
+in a single process, or in different processes within the same ERT run (for
+example two consecutive forward-model steps). Each call produces its own
+attach session, so debugging *N* breaks requires *N* attaches. **NB! Make
+sure that debugging is not attempted in ensemble runs with several
+realizations**.
 
 ## Inserting the call
 
@@ -81,21 +81,26 @@ next free port when 5678 is still in `TIME_WAIT`.
 
 ## Workflow for an ERT run
 
+The sequence below describes what to expect when `wait_for_debugger()` is
+reached more than once during an ERT run (either multiple breaks in the same
+process, or one break each in two consecutive forward-model steps).
+
 1. Start the ERT run as usual.
-2. When the **pre-experiment** process hits `wait_for_debugger()` you see a
-   popup like `⏸ Waiting for debugger to attach on localhost:5678 (pid …)`.
-   Note the port (also written to `/tmp/debug_attach.log`).
+2. When the first `wait_for_debugger()` call is reached you see a popup like
+   `⏸ Waiting for debugger to attach on localhost:5678 (pid …)`. Note the
+   port (also written to `/tmp/debug_attach.log`).
 3. In VS Code, pick **Python: Debug Server (prompt for port)** from the
-   Run-and-Debug dropdown, press F5, and enter the port (`5678` for the first
-   process). Debug normally.
-4. When you are done with the pre-experiment session, click the **Disconnect**
-   button (the plug icon) in the VS Code debug toolbar. **This step is
-   required** — `debugpy` only allows one client at a time, so the next
-   process cannot accept a connection until you detach.
-5. The **forward model** process now hits its own `wait_for_debugger()` call
-   and writes a second line to the log, typically with port `5679` because
-   `5678` is still in `TIME_WAIT` on Linux. Note the new port.
-6. Press F5 again and enter the new port when prompted.
+   Run-and-Debug dropdown, press F5, and enter the port (`5678` for the
+   first break). Debug normally.
+4. When you are done with that session, click the **Disconnect** button (the
+   plug icon) in the VS Code debug toolbar. **This step is required** —
+   `debugpy` only allows one client at a time, so the next break cannot
+   accept a connection until you detach.
+5. The next `wait_for_debugger()` call writes a second line to the log,
+   typically with port `5679` because `5678` is still in `TIME_WAIT` on Linux
+   (within the same process the original port is reused). Note the port
+   shown in the log.
+6. Press F5 again and enter that port when prompted.
 
 You can monitor the log live in a separate terminal:
 

--- a/src/fmu/pem/forward_models/pem_model.py
+++ b/src/fmu/pem/forward_models/pem_model.py
@@ -41,23 +41,10 @@ class PetroElasticModel(ForwardModelStepPlugin):
     ) -> ForwardModelStepJSON:
         return fm_step_json
 
-    def validate_pre_experiment(self, fm_step_json: ForwardModelStepJSON) -> None:
-        # Parse YAML parameter file by pydantic pre-experiment to catch errors at an
-        # early stage. At this point the per-realization directory tree does not yet
-        # exist, so realization-specific filesystem checks must be skipped.
-        # pre_experiment=True is passed to read_pem_config so that realization-specific
-        # filesystem validators are suppressed, while validators for non-path parameters
-        # (types, ranges, etc.) still run normally.
-
-        args = parse_arguments(fm_step_json["argList"])
-
-        try:
-            with restore_dir(args.model_dir):
-                _ = read_pem_config(args.config_file, pre_experiment=True)
-        except Exception as e:
-            raise ForwardModelStepValidationError(
-                f"pem pre-experiment validation failed: {str(e)}"
-            )
+    def validate_pre_experiment(self, _fm_step_json: ForwardModelStepJSON) -> None:
+        # No-op: fmu-pem depends on files created later in the ERT workflow,
+        # so pre-experiment validation cannot meaningfully verify them.
+        pass
 
     @staticmethod
     def documentation() -> ForwardModelStepDocumentation | None:


### PR DESCRIPTION
## Pre-experiment validation

It is observed that the `ert` pre-experiment validation is only partly able to validate the conditions needed for `fmu-pem` to run successfully. Several files are generated during the full sequence of `ert` forward models, and they are not present to validate at pre-experiment phase. Discussions with the `ert` maintenance team reveals that the intention of pre-experiment validation is not as required by `fmu-pem`.

Closes #156 