### PR TITLE
feat (pem): add porosity to the intermediate outputs when  it is modified in PEM

### DIFF
--- a/src/fmu/pem/pem_utilities/export_routines.py
+++ b/src/fmu/pem/pem_utilities/export_routines.py
@@ -17,7 +17,7 @@ from .utils import _verify_export_inputs, pem_logger, restore_dir
 
 def save_results(
     config_dir: Path,
-    sim_grid: xtgeo.grid3d.Grid,
+    sim_grid: xtgeo.Grid,
     grid_name: str,
     seis_dates: list[str],
     save_to_disk: bool,
@@ -32,6 +32,7 @@ def save_results(
     fluid_props: list[EffectiveFluidProperties],
     bubble_point_grids: list[dict[str, np.ma.MaskedArray]],
     dry_rock_props: list[DryRockProperties],
+    modified_porosity: dict[str, xtgeo.GridProperty] | None,
 ) -> None:
     """Saves all intermediate and final results according to the settings in the PEM
     and global config files
@@ -52,6 +53,10 @@ def save_results(
         difference_date_strs: dates for difference calculation
         matrix_props: intermediate results - mineral properties
         fluid_props: intermediate results - fluid properties per time step
+        bubble_point_grids: intermediate results - grid with pressure below bubble
+            point
+        dry_rock_props: intermediate results - bulk modulus, shear modulus and density
+        modified_porosity: intermediate result - adjusted porosity property
 
     Returns:
         None, warning or KeyError
@@ -125,6 +130,12 @@ def save_results(
                 "_DRY_ROCK",
             ]
             dates = [seis_dates, None, seis_dates, seis_dates]
+
+            if modified_porosity is not None:
+                suffices.append("")
+                export_dicts.append(modified_porosity)
+                dates.append(None)
+
             for props, date_info, suffix in zip(export_dicts, dates, suffices):
                 export_results_disk(
                     result_props=props,

--- a/src/fmu/pem/run_pem.py
+++ b/src/fmu/pem/run_pem.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from fmu.pem import pem_functions as pem_fcns
 from fmu.pem import pem_utilities as pem_utils
+from fmu.pem.pem_utilities.pem_config_validation import ConstantNonNetPorosity
 from fmu.pem.pem_utilities.utils import (
     pem_log,
     start_pem_run_log,
@@ -46,6 +47,16 @@ def pem_fcn(
                 sim_grid=sim_grid,
                 root_dir=run_dir,
             )
+
+            # It is only in the cases that porosity is adjusted by the NTG property
+            # that it is interesting to export it for QC purposes, otherwise it is
+            # estimated in the reservoir simulator or geomodel
+            if isinstance(
+                config.rock_matrix.porosity_adjustment, ConstantNonNetPorosity
+            ):
+                adjusted_porosity = {"adjusted_porosity": constant_props.poro}
+            else:
+                adjusted_porosity = None
 
             # Calculate rock properties - fluids and minerals
             # Effective mineral (matrix) properties - one set valid for all time-steps
@@ -140,6 +151,7 @@ def pem_fcn(
                 fluid_props=fluid_properties,
                 bubble_point_grids=below_bp_grids,
                 dry_rock_props=dry_rock,
+                modified_porosity=adjusted_porosity,
             )
             pem_log("saved results, process finished")
     finally:


### PR DESCRIPTION
## Problem

When porosity is adjusted inside `fmu-pem` (the `ConstantNonNetPorosity`
case, where reservoir-simulator NTG is folded into the effective porosity
used by the rock-physics models), the adjusted grid was discarded after
use. There was no way to QC it against the porosity coming from the
reservoir simulator or the geomodel. Tracked as #154.

## Solution

Export the adjusted porosity as an intermediate result, but only when it
has actually been modified by `fmu-pem`. When porosity is taken straight
from the simulator/geomodel, nothing extra is written.

- In `run_pem.py`, build an `adjusted_porosity` dict from
  `constant_props.poro` only when `config.rock_matrix.porosity_adjustment`
  is a `ConstantNonNetPorosity` instance; otherwise pass `None`.
- In `export_routines.save_results`, add a `modified_porosity` argument
  and append it to the intermediate export batch (no date suffix) when
  non-`None`, so the file lands in `share/results/grids` under the
  standard `<SIMGRIDNAME>--adjusted_porosity.roff` naming.
- Tighten the `sim_grid` type hint to `xtgeo.Grid` and add docstring
  entries for the previously undocumented `bubble_point_grids`,
  `dry_rock_props` and the new `modified_porosity` parameter.

## Changes

- **feat(pem): export adjusted porosity as intermediate result when PEM
  modifies it** — single commit `73b6a65`
  - `src/fmu/pem/run_pem.py`: detect the `ConstantNonNetPorosity` case
    and forward the adjusted porosity to `save_results`.
  - `src/fmu/pem/pem_utilities/export_routines.py`: add the
    `modified_porosity` parameter, append it to the intermediate export
    loop, refresh the type hint and docstring.

Closes #154 