### PR TITLE
Feat/cleanup qc intermediate results

### DIFF
--- a/documentation/docs/.vitepress/config.mts
+++ b/documentation/docs/.vitepress/config.mts
@@ -41,7 +41,8 @@ export default defineConfig({
                     },
                     {text: 'Command-line-runs', link: 'command-line-runs'},
                     {text: 'ERT configuration', link: '/ert-configuration'},
-                    {text: 'PEM configuration', link: '/pem-configuration'}
+                    {text: 'PEM configuration', link: '/pem-configuration'},
+                    {text: 'Cleaning up results', link: '/cleanup'}
                 ]
             },
             {

--- a/documentation/docs/cleanup.md
+++ b/documentation/docs/cleanup.md
@@ -1,0 +1,103 @@
+# Cleaning up PEM results
+
+A full PEM run can write a large number of grids to each realisation's
+`share/results/grids` directory: the final elastic and difference properties, but
+also – when enabled – many intermediate/QC grids (mineral, fluid, dry-rock,
+pressure, adjusted-porosity, below-bubble-point, …). Once a run has been
+quality-checked, most of these are no longer needed and take up considerable
+disk space.
+
+The `pem_cleanup` tool removes selected categories of result files, either from a
+single run or from a whole ensemble. It is available both as a command-line
+program and as a pre-installed ERT forward model (`PEM_CLEANUP`).
+
+## What gets removed
+
+Each grid file is classified, from its file name, into one of four categories:
+
+| Category       | Examples                                                                 |
+| -------------- | ------------------------------------------------------------------------ |
+| `intermediate` | `simgrid--bulk_modulus_mineral.roff`, `simgrid--pressure--20180101.roff` |
+| `elastic`      | `simgrid--vp--20180101.roff`, `simgrid--density--20180101.roff`          |
+| `difference`   | `simgrid--sidiffpercent--20180701_20180101.roff`                         |
+| `grid`         | `simgrid.roff` (the bare simulation grid)                                |
+
+You select which categories to delete. The special value `all` deletes everything
+that is recognised. `grid` is a *classification* only – it is not selectable on its
+own (see the warning below).
+
+::: warning Protecting the simulation grid
+The bare grid (`grid`) is only removed when **everything** is removed – that is,
+when you pass `all`. It cannot be selected on its own: `grid` is not a valid value
+for `--save_type_list`, because the elastic/difference/intermediate parameter grids
+are unusable without the grid geometry they refer to. Requesting only some property
+categories therefore never deletes the grid.
+Files that are not recognised as PEM output (e.g. notes, logs) are always left
+untouched.
+:::
+
+## Command-line usage
+
+```shell
+> # Show all call arguments
+> pem_cleanup --help
+```
+
+| Flag                     | Required | Default     | Description                                                                    |
+| ------------------------ | -------- | ----------- | ------------------------------------------------------------------------------ |
+| `-g`, `--grid_dir`       | yes      | –           | Directory to clean (see [Which directory](#which-directory-to-point-at) below) |
+| `-s`, `--save_type_list` | yes      | –           | One or more categories: `intermediate`, `elastic`, `difference`, `all`         |
+| `-i`, `--is_ensemble`    | no       | `false`     | Treat `--grid_dir` as the top of an ensemble                                   |
+| `-p`, `--prefix`         | no       | `simgrid`   | Grid-name prefix of the files to consider                                      |
+| `-e`, `--extension`      | no       | `.roff`     | File extension of the files to consider                                        |
+
+```shell
+> # Go to the top of the project structure
+> cd /project/<my project>/resmod/ff/users/26.0.0
+
+> # Remove only the intermediate/QC grids from one run
+> pem_cleanup -g ./share/results/grids -s intermediate
+
+> # Remove intermediate and difference grids (keeps elastic and the grid itself)
+> pem_cleanup -g ./share/results/grids -s intermediate difference
+
+> # Remove everything PEM produced, including the grid
+> pem_cleanup -g ./share/results/grids -s all
+
+> # Clean every realisation/iteration of an ensemble in one call
+> # (point at the ensemble top that directly contains realization-<n>/iter-<m>)
+> pem_cleanup -g /scratch/fmu/<user>/<case> -i true -s all
+```
+
+### Which directory to point at
+
+`pem_cleanup` deliberately accepts only a small, well-defined set of locations;
+no upward or recursive search is performed, so an unrelated parent directory can
+never be matched.
+
+- **Single run** (`--is_ensemble false`, the default): `--grid_dir` must be either
+  - the `share/results/grids` directory itself, or
+  - the FMU run root that contains it directly.
+- **Ensemble** (`--is_ensemble true`): `--grid_dir` must be the top of the
+  ensemble, i.e. a directory that directly contains `realization-<n>/iter-<m>`
+  subdirectories. Every realisation/iteration's `share/results/grids` directory is
+  then processed.
+
+If the directory does not match the requested run type, the tool stops with an
+error rather than risk deleting the wrong files.
+
+## ERT configuration
+
+`PEM_CLEANUP` is a pre-installed forward model and is typically added after the
+`PEM` step (and after any QC steps you want to run on the intermediate grids).
+
+````ert
+-- Define your variables:
+DEFINE <GRID_DIR> <RUNPATH>/share/results/grids
+DEFINE <SAVE_TYPES> intermediate
+DEFINE <GRID_PREFIX> simgrid
+DEFINE <GRID_EXTENSION> .roff
+
+-- Run the pre-installed ERT forward model:
+FORWARD_MODEL PEM_CLEANUP(<GRID_DIR>=<GRID_DIR>, <SAVE_TYPE_LIST>=<SAVE_TYPES>, <PREFIX>=<GRID_PREFIX>, <EXTENSION>=<GRID_EXTENSION>)
+````

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ Repository = "https://github.com/equinor/fmu-pem"
 
 [project.scripts]
 pem = "fmu.pem.__main__:main"
+pem_cleanup = "fmu.pem.run_cleanup:run_pem_cleanup"
 
 [project.entry-points.ert]
 pem_jobs = "fmu.pem.hook_implementations.jobs"

--- a/src/fmu/pem/__init__.py
+++ b/src/fmu/pem/__init__.py
@@ -1,7 +1,9 @@
 from .__main__ import main as pem
+from .run_cleanup import run_pem_cleanup as pem_cleanup
 from .run_pem import pem_fcn
 
 __all__ = [
     "pem_fcn",
     "pem",
+    "pem_cleanup",
 ]

--- a/src/fmu/pem/forward_models/__init__.py
+++ b/src/fmu/pem/forward_models/__init__.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+from .pem_cleanup import PemCleanup
 from .pem_model import PetroElasticModel
 
 __all__ = [
     "PetroElasticModel",
+    "PemCleanup",
 ]

--- a/src/fmu/pem/forward_models/pem_cleanup.py
+++ b/src/fmu/pem/forward_models/pem_cleanup.py
@@ -17,8 +17,6 @@ class PemCleanup(ForwardModelStepPlugin):
                 "<GRID_DIR>",
                 "--save_type_list",
                 "<SAVE_TYPE_LIST>",
-                "--is_ensemble",
-                "<IS_ENSEMBLE>",
                 "--prefix",
                 "<PREFIX>",
                 "--extension",
@@ -44,7 +42,7 @@ class PemCleanup(ForwardModelStepPlugin):
             examples="""
 .. code-block:: console
 
-  FORWARD_MODEL PEM_CLEANUP(<GRID_DIR>=<RUNPATH>/share/results/grids, <SAVE_TYPE_LIST>=intermediate, <IS_ENSEMBLE>=false, <PREFIX>=simgrid, <EXTENSION>=.roff)
+  FORWARD_MODEL PEM_CLEANUP(<GRID_DIR>=<RUNPATH>/share/results/grids, <SAVE_TYPE_LIST>=intermediate, <PREFIX>=simgrid, <EXTENSION>=.roff)
 
 """,  # noqa: E501
         )

--- a/src/fmu/pem/forward_models/pem_cleanup.py
+++ b/src/fmu/pem/forward_models/pem_cleanup.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from ert import (
+    ForwardModelStepDocumentation,
+    ForwardModelStepJSON,
+    ForwardModelStepPlugin,
+)
+
+# from grid3d_maps.aggregate.grid3d_aggregate_map import DESCRIPTION
+
+
+class PemCleanup(ForwardModelStepPlugin):
+    def __init__(self) -> None:
+        super().__init__(
+            name="PEM_CLEANUP",
+            command=[
+                "pem_cleanup",
+                "--grid_dir",
+                "<GRID_DIR>",
+                "--save_type_list",
+                "<SAVE_TYPE_LIST>",
+                "--is_ensemble",
+                "<IS_ENSEMBLE>",
+                "--prefix",
+                "<PREFIX>",
+                "--extension",
+                "<EXTENSION>",
+            ],
+        )
+
+    def validate_pre_realization_run(
+        self, fm_step_json: ForwardModelStepJSON
+    ) -> ForwardModelStepJSON:
+        return fm_step_json
+
+    def validate_pre_experiment(self, fm_step_json: ForwardModelStepJSON) -> None:
+        pass
+
+    @staticmethod
+    def documentation() -> ForwardModelStepDocumentation | None:
+        return ForwardModelStepDocumentation(
+            category="modelling.reservoir",
+            source_package="fmu.pem",
+            source_function_name="PemCleanup",
+            description="",
+            examples=(
+                "code-block:: console\n\n"
+                "FORWARD_MODEL PEM_CLEANUP("
+                "<GRID_DIR>=<RUNPATH>/share/results/grids, "
+                "<SAVE_TYPE_LIST>=intermediate, differences "
+                "<IS_ENSEMBLE>=false "
+                "<PREFIX>=simgrid "
+                "<EXTENSION>=.roff"
+            ),
+        )

--- a/src/fmu/pem/forward_models/pem_cleanup.py
+++ b/src/fmu/pem/forward_models/pem_cleanup.py
@@ -6,8 +6,6 @@ from ert import (
     ForwardModelStepPlugin,
 )
 
-# from grid3d_maps.aggregate.grid3d_aggregate_map import DESCRIPTION
-
 
 class PemCleanup(ForwardModelStepPlugin):
     def __init__(self) -> None:
@@ -33,7 +31,7 @@ class PemCleanup(ForwardModelStepPlugin):
     ) -> ForwardModelStepJSON:
         return fm_step_json
 
-    def validate_pre_experiment(self, fm_step_json: ForwardModelStepJSON) -> None:
+    def validate_pre_experiment(self, _fm_step_json: ForwardModelStepJSON) -> None:
         pass
 
     @staticmethod
@@ -43,13 +41,10 @@ class PemCleanup(ForwardModelStepPlugin):
             source_package="fmu.pem",
             source_function_name="PemCleanup",
             description="",
-            examples=(
-                "code-block:: console\n\n"
-                "FORWARD_MODEL PEM_CLEANUP("
-                "<GRID_DIR>=<RUNPATH>/share/results/grids, "
-                "<SAVE_TYPE_LIST>=intermediate, differences "
-                "<IS_ENSEMBLE>=false "
-                "<PREFIX>=simgrid "
-                "<EXTENSION>=.roff"
-            ),
+            examples="""
+.. code-block:: console
+
+  FORWARD_MODEL PEM_CLEANUP(<GRID_DIR>=<RUNPATH>/share/results/grids, <SAVE_TYPE_LIST>=intermediate, <IS_ENSEMBLE>=false, <PREFIX>=simgrid, <EXTENSION>=.roff)
+
+""",  # noqa: E501
         )

--- a/src/fmu/pem/hook_implementations/jobs.py
+++ b/src/fmu/pem/hook_implementations/jobs.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import ert
 
-from fmu.pem.forward_models import PetroElasticModel
+from fmu.pem.forward_models import PemCleanup, PetroElasticModel
 
 PLUGIN_NAME = "pem"
 
@@ -15,5 +15,6 @@ def installable_workflow_jobs() -> dict[str, str]:
 @ert.plugin(name=PLUGIN_NAME)
 def installable_forward_model_steps() -> list[ert.ForwardModelStepPlugin]:
     return [  # type: ignore
+        PemCleanup,
         PetroElasticModel,
     ]

--- a/src/fmu/pem/pem_utilities/argument_parser.py
+++ b/src/fmu/pem/pem_utilities/argument_parser.py
@@ -84,7 +84,10 @@ def parse_cleanup(
         "--save_type_list",
         nargs="+",
         type=str,
-        choices=[t.value for t in SaveTypes],
+        # 'grid' is intentionally not selectable on its own: the grid is only removed
+        # together with everything else (via 'all'), since the parameter files are
+        # useless without it.
+        choices=[t.value for t in SaveTypes if t is not SaveTypes.GRID],
         required=True,
         help="List of save batches: 'all', 'intermediate', 'difference', 'elastic'",
     )

--- a/src/fmu/pem/pem_utilities/argument_parser.py
+++ b/src/fmu/pem/pem_utilities/argument_parser.py
@@ -1,6 +1,8 @@
 import argparse
 from pathlib import Path
 
+from fmu.pem.pem_utilities.enum_defs import SaveTypes
+
 
 def _str2bool(value: object) -> bool:
     if isinstance(value, bool):
@@ -19,7 +21,7 @@ def parse_arguments(
     arguments: list[str],
 ) -> argparse.Namespace:
     """
-    Uses argparse to parse arguments as expected from command line invocation
+    Uses argparse to parse arguments as expected from command line invocation for pem
     """
     parser = argparse.ArgumentParser(__file__)
     parser.add_argument(
@@ -51,7 +53,6 @@ def parse_arguments(
         default=False,
         help="Select verbose or minimal output",
     )
-
     # Split config and global path into directory and file name, as this is
     # required in the PEM
     args = parser.parse_args(arguments)
@@ -61,3 +62,54 @@ def parse_arguments(
     args.global_file = Path(args.global_file.name)
 
     return args
+
+
+def parse_cleanup(
+    arguments: list[str],
+) -> argparse.Namespace:
+    """
+    Uses argparse to parse arguments as expected from command line invocation for
+    pem_cleanup
+    """
+    parser = argparse.ArgumentParser(__file__)
+    parser.add_argument(
+        "-g",
+        "--grid_dir",
+        type=Path,
+        required=True,
+        help="Path name of the directory with grid files from PEM run",
+    )
+    parser.add_argument(
+        "-s",
+        "--save_type_list",
+        nargs="+",
+        type=str,
+        choices=[t.value for t in SaveTypes],
+        required=True,
+        help="List of save batches: 'all', 'intermediate', 'difference', 'elastic'",
+    )
+    parser.add_argument(
+        "-i",
+        "--is_ensemble",
+        type=_str2bool,
+        required=False,
+        default=False,
+        help="Delete all grids in an ensemble run, default=False",
+    )
+    parser.add_argument(
+        "-p",
+        "--prefix",
+        type=str,
+        default="simgrid",
+        required=False,
+        help="Prefix in grid file names, default='simgrid'",
+    )
+    parser.add_argument(
+        "-e",
+        "--extension",
+        type=str,
+        default=".roff",
+        required=False,
+        help="Grid file name extension, default='.roff'",
+    )
+    return parser.parse_args(arguments)

--- a/src/fmu/pem/pem_utilities/cleanup.py
+++ b/src/fmu/pem/pem_utilities/cleanup.py
@@ -17,7 +17,7 @@ _INTERMEDIATE_MARKERS = (
     "_fluid",
     "_dry_rock",
     "below_bubble_point",
-    "_adjusted_porosity",
+    "adjusted_porosity",
     "pressure",
 )
 

--- a/src/fmu/pem/pem_utilities/cleanup.py
+++ b/src/fmu/pem/pem_utilities/cleanup.py
@@ -205,7 +205,7 @@ def _resolve_remove_categories(remove_categories: list[SaveTypes]) -> set[SaveTy
 
 def cleanup_pem_results(
     directory: Path,
-    suffix: str,
+    prefix: str,
     extension: str,
     remove_categories: list[SaveTypes | str],
     is_ensemble: bool = False,
@@ -234,7 +234,7 @@ def cleanup_pem_results(
     ----------
     directory : Path
         The ensemble top (``is_ensemble=True``) or a single-run grids/root directory.
-    suffix : str
+    prefix : str
         Grid-name prefix of the files to consider (e.g. ``"simgrid"``).
     extension : str
         File extension of the files to consider (e.g. ``".roff"``).
@@ -252,7 +252,7 @@ def cleanup_pem_results(
         grids_dirs = iter([_find_run_grids_dir(directory)])
     categories_to_remove = _resolve_remove_categories(categories)
     for grids_dir in grids_dirs:
-        type_dict = make_type_dict(grids_dir, suffix, extension)
+        type_dict = make_type_dict(grids_dir, prefix, extension)
         remove_files(
             [
                 path

--- a/src/fmu/pem/pem_utilities/cleanup.py
+++ b/src/fmu/pem/pem_utilities/cleanup.py
@@ -1,0 +1,262 @@
+from datetime import datetime
+from pathlib import Path
+from typing import Iterator
+
+from fmu.pem.pem_utilities.enum_defs import SaveTypes
+
+# Exported result files follow the grammar ``<grid>--<attribute>[--<date(s)>].<ext>``
+# (separator is ``--``). Dates are formatted as ``YYYYMMDD``; a difference property
+# carries two of them joined by an underscore, e.g. ``20180701_20180101``.
+_DATE_FORMAT = "%Y%m%d"
+
+# Substrings in the attribute token that mark a QC/intermediate result. ``pressure``
+# also captures ``effective_pressure`` and ``overburden_pressure``; the ``_fluid`` /
+# ``_mineral`` / ``_dry_rock`` markers also catch the intermediate ``density`` grids.
+_INTERMEDIATE_MARKERS = (
+    "_mineral",
+    "_fluid",
+    "_dry_rock",
+    "below_bubble_point",
+    "_adjusted_porosity",
+    "pressure",
+)
+
+# The three "property" save types; the grid itself is handled separately.
+_PROPERTY_CATEGORIES = (
+    SaveTypes.INTERMEDIATE_PROPERTIES,
+    SaveTypes.ELASTIC_PROPERTIES,
+    SaveTypes.DIFFERENCE_PROPERTIES,
+)
+
+# Result grids live in the FMU ``<run>/share/results/grids`` directory; ensemble runs
+# add a ``<project>/realization-<n>/iter-<m>/`` prefix (see ERT RUNPATH).
+_GRIDS_SUBPATH = ("share", "results", "grids")
+_GRIDS_GLOB = "/".join(_GRIDS_SUBPATH)
+_REALIZATION_GLOB = "realization-*/iter-*"
+
+
+def _count_dates(text: str) -> int:
+    """Count valid ``YYYYMMDD`` dates in an underscore-separated string.
+
+    Validation uses :func:`datetime.strptime`, so only real calendar dates are
+    counted rather than any run of eight digits.
+    """
+    dates = 0
+    for token in text.split("_"):
+        try:
+            datetime.strptime(token, _DATE_FORMAT)
+        except ValueError:
+            continue
+        dates += 1
+    return dates
+
+
+def categorise_filename(filename: Path) -> SaveTypes | None:
+    """Classify a single result file into one of the :class:`SaveTypes`.
+
+    Classification is driven by the structure of the name (split on ``--``) and the
+    number of dates it carries:
+
+    - two dates                     -> difference property
+    - an intermediate marker        -> intermediate property (with or without date)
+    - a single date, no marker      -> elastic property
+    - no attribute (bare grid name) -> grid
+
+    Returns ``None`` for files that do not match the expected pattern.
+    """
+    # parts == [grid] for the grid itself, otherwise [grid, attribute, date(s)?].
+    parts = filename.stem.split("--")
+    if len(parts) == 1:
+        return SaveTypes.GRID
+
+    attribute = parts[1]
+    date_part = parts[2] if len(parts) > 2 else ""
+    n_dates = _count_dates(date_part)
+
+    if n_dates == 2:
+        return SaveTypes.DIFFERENCE_PROPERTIES
+    if any(marker in attribute for marker in _INTERMEDIATE_MARKERS):
+        return SaveTypes.INTERMEDIATE_PROPERTIES
+    if n_dates == 1:
+        return SaveTypes.ELASTIC_PROPERTIES
+    return None
+
+
+def make_type_dict(
+    directory_path: Path,
+    suffix: str = "simgrid",
+    extension: str = ".roff",
+) -> dict[Path, SaveTypes]:
+    """Map every matching file in ``directory_path`` to its :class:`SaveTypes`.
+
+    Only files whose name starts with ``suffix`` and ends with ``extension`` are
+    considered; unrecognised names are skipped.
+    """
+    type_dict: dict[Path, SaveTypes] = {}
+    for file_path in sorted(directory_path.glob(f"{suffix}*{extension}")):
+        category = categorise_filename(file_path)
+        if category is not None:
+            type_dict[file_path] = category
+    return type_dict
+
+
+def remove_files(file_names: list[Path]) -> None:
+    """Unlink every file in ``file_names``.
+
+    Raises ``OSError`` if one or more files could not be deleted.
+    """
+    not_deleted = []
+    for file_name in file_names:
+        try:
+            file_name.unlink(missing_ok=True)
+        except OSError:
+            not_deleted.append(file_name)
+    if not_deleted:
+        raise OSError(
+            "cleanup: could not delete the following files: "
+            + ", ".join(str(path) for path in not_deleted)
+        )
+
+
+def crawl_ensemble(directory_path: Path) -> Iterator[Path]:
+    """Yield the ``share/results/grids`` directory of every realisation/iteration.
+
+    ``directory_path`` MUST be the top of the ensemble, i.e. directly contain
+    ``realization-<n>/iter-<m>`` subdirectories (no upward or recursive search is
+    performed). Raises ``ValueError`` if it is not.
+    """
+    directory_path = directory_path.resolve()
+    grids_dirs = sorted(
+        path
+        for path in directory_path.glob(f"{_REALIZATION_GLOB}/{_GRIDS_GLOB}")
+        if path.is_dir()
+    )
+    if not grids_dirs:
+        raise ValueError(
+            f"cleanup: {directory_path} is not the top of an FMU ensemble; expected "
+            "'realization-*/iter-*' subdirectories below it"
+        )
+    yield from grids_dirs
+
+
+def _is_grids_dir(path: Path) -> bool:
+    """Return ``True`` if ``path`` is an FMU ``.../share/results/grids`` directory."""
+    return path.is_dir() and path.parts[-len(_GRIDS_SUBPATH) :] == _GRIDS_SUBPATH
+
+
+def _find_run_grids_dir(directory_path: Path) -> Path:
+    """Resolve the single ``share/results/grids`` directory of a one-off run.
+
+    Accepts exactly one of:
+
+    - the grids directory itself (``.../share/results/grids``), or
+    - the FMU run root that contains it directly (as returned by
+      ``_resolve_fmu_rootpath``).
+
+    No upward or recursive search is performed, so an unrelated parent can never be
+    matched. Raises ``ValueError`` for any other location.
+    """
+    directory_path = directory_path.resolve()
+    if _is_grids_dir(directory_path):
+        return directory_path
+    run_grids = directory_path.joinpath(*_GRIDS_SUBPATH)
+    if _is_grids_dir(run_grids):
+        return run_grids
+    raise ValueError(
+        f"cleanup: {directory_path} is not a single FMU run location; expected a "
+        "'share/results/grids' directory or an FMU run root that contains it directly"
+    )
+
+
+def _normalise_remove_categories(
+    remove_categories: list[SaveTypes | str],
+) -> list[SaveTypes]:
+    """Coerce each requested category to a :class:`SaveTypes` member.
+
+    Plain strings matching a save-type value (e.g. ``"elastic"``) are accepted and
+    converted. Raises ``ValueError`` with the list of valid options for any value
+    that is not a recognised save type, so typos fail loudly instead of silently
+    deleting nothing.
+    """
+    normalised = []
+    for category in remove_categories:
+        try:
+            normalised.append(SaveTypes(category))
+        except ValueError:
+            raise ValueError(
+                f"cleanup: '{category}' is not a valid save type; "
+                f"expected one of: {SaveTypes.options()}"
+            ) from None
+    return normalised
+
+
+def _resolve_remove_categories(remove_categories: list[SaveTypes]) -> set[SaveTypes]:
+    """Expand the requested categories into the concrete set of types to delete.
+
+    The grid is removed only alongside everything else: either when ``SaveTypes.ALL``
+    is requested, or when all three property categories are listed explicitly.
+    """
+    requested = set(remove_categories)
+    if SaveTypes.ALL in requested or set(_PROPERTY_CATEGORIES).issubset(requested):
+        return {*_PROPERTY_CATEGORIES, SaveTypes.GRID}
+    # Otherwise act only on the requested property categories, never the grid.
+    return requested & set(_PROPERTY_CATEGORIES)
+
+
+def cleanup_pem_results(
+    directory: Path,
+    suffix: str,
+    extension: str,
+    remove_categories: list[SaveTypes | str],
+    is_ensemble: bool = False,
+) -> None:
+    """Remove selected PEM result files from a single run or a whole ensemble.
+
+    ``directory`` must be one of a small set of well-defined FMU locations; no upward
+    or recursive search is performed, so an unrelated parent can never be matched:
+
+    - ``is_ensemble=False`` (single run): the ``share/results/grids`` directory itself,
+      or the FMU run root that contains it directly (as returned by
+      ``_resolve_fmu_rootpath``).
+    - ``is_ensemble=True`` (ensemble): the top of the ensemble, which MUST directly
+      contain ``realization-<n>/iter-<m>`` subdirectories; every realisation/iteration
+      ``share/results/grids`` directory is then processed.
+
+    A ``ValueError`` is raised if ``directory`` does not match the requested run type.
+
+    If SaveTypes.ALL is in the list, all recognised files are deleted. If not, files
+    are deleted according to categories.
+
+    SaveTypes.GRID is only removed if SaveTypes.ALL is set, or the three distinct
+    categories are all given.
+
+    Parameters
+    ----------
+    directory : Path
+        The ensemble top (``is_ensemble=True``) or a single-run grids/root directory.
+    suffix : str
+        Grid-name prefix of the files to consider (e.g. ``"simgrid"``).
+    extension : str
+        File extension of the files to consider (e.g. ``".roff"``).
+    remove_categories : list[SaveTypes | str]
+        Categories of files to delete. Plain strings matching a save-type value
+        (e.g. ``"elastic"``) are accepted; an unrecognised value raises
+        ``ValueError``.
+    is_ensemble : bool, optional
+        Treat ``directory`` as part of an ensemble, by default False.
+    """
+    categories = _normalise_remove_categories(remove_categories)
+    if is_ensemble:
+        grids_dirs: Iterator[Path] = crawl_ensemble(directory)
+    else:
+        grids_dirs = iter([_find_run_grids_dir(directory)])
+    categories_to_remove = _resolve_remove_categories(categories)
+    for grids_dir in grids_dirs:
+        type_dict = make_type_dict(grids_dir, suffix, extension)
+        remove_files(
+            [
+                path
+                for path, category in type_dict.items()
+                if category in categories_to_remove
+            ]
+        )

--- a/src/fmu/pem/pem_utilities/cleanup.py
+++ b/src/fmu/pem/pem_utilities/cleanup.py
@@ -68,6 +68,10 @@ def categorise_filename(filename: Path) -> SaveTypes | None:
     parts = filename.stem.split("--")
     if len(parts) == 1:
         return SaveTypes.GRID
+    if len(parts) > 3:
+        # More segments than the grammar allows: treat as unrecognised so we never
+        # delete an unexpected file.
+        return None
 
     attribute = parts[1]
     date_part = parts[2] if len(parts) > 2 else ""

--- a/src/fmu/pem/pem_utilities/enum_defs.py
+++ b/src/fmu/pem/pem_utilities/enum_defs.py
@@ -141,3 +141,11 @@ class Sim2SeisRequiredParams(_OptionsMixin, str, Enum):
     VP = "vp"
     VS = "vs"
     DENSITY = "density"
+
+
+class SaveTypes(_OptionsMixin, str, Enum):
+    INTERMEDIATE_PROPERTIES = "intermediate"
+    ELASTIC_PROPERTIES = "elastic"
+    DIFFERENCE_PROPERTIES = "difference"
+    GRID = "grid"
+    ALL = "all"

--- a/src/fmu/pem/run_cleanup.py
+++ b/src/fmu/pem/run_cleanup.py
@@ -13,16 +13,13 @@ def run_pem_cleanup(args_list=None):
         args_list = sys.argv[1:]
     args = parse_cleanup(args_list)
 
-    run_folder = _resolve_fmu_rootpath(config_dir=args.grid_dir.absolute())
-
-    with restore_dir(run_folder):
-        cleanup_pem_results(
-            directory=args.grid_dir,
-            remove_categories=args.save_type_list,
-            is_ensemble=args.is_ensemble,
-            prefix=args.prefix,
-            extension=args.extension,
-        )
+    cleanup_pem_results(
+        directory=args.grid_dir,
+        remove_categories=args.save_type_list,
+        is_ensemble=args.is_ensemble,
+        prefix=args.prefix,
+        extension=args.extension,
+    )
 
 
 if __name__ == "__main__":

--- a/src/fmu/pem/run_cleanup.py
+++ b/src/fmu/pem/run_cleanup.py
@@ -1,9 +1,5 @@
-import os
 import sys
-from pathlib import Path
 
-from fmu.pem.__main__ import _resolve_fmu_rootpath
-from fmu.pem.pem_utilities import restore_dir
 from fmu.pem.pem_utilities.argument_parser import parse_cleanup
 from fmu.pem.pem_utilities.cleanup import cleanup_pem_results
 

--- a/src/fmu/pem/run_cleanup.py
+++ b/src/fmu/pem/run_cleanup.py
@@ -1,0 +1,29 @@
+import os
+import sys
+from pathlib import Path
+
+from fmu.pem.__main__ import _resolve_fmu_rootpath
+from fmu.pem.pem_utilities import restore_dir
+from fmu.pem.pem_utilities.argument_parser import parse_cleanup
+from fmu.pem.pem_utilities.cleanup import cleanup_pem_results
+
+
+def run_pem_cleanup(args_list=None):
+    if args_list is None:
+        args_list = sys.argv[1:]
+    args = parse_cleanup(args_list)
+
+    run_folder = _resolve_fmu_rootpath(config_dir=args.grid_dir.absolute())
+
+    with restore_dir(run_folder):
+        cleanup_pem_results(
+            directory=args.grid_dir,
+            remove_categories=args.save_type_list,
+            is_ensemble=args.is_ensemble,
+            prefix=args.prefix,
+            extension=args.extension,
+        )
+
+
+if __name__ == "__main__":
+    run_pem_cleanup()

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -133,6 +133,11 @@ def test_categorise_filename_invalid_date_returns_none():
     assert categorise_filename(Path("simgrid--vp--20181301.roff")) is None
 
 
+def test_categorise_filename_extra_segments_returns_none():
+    # More ``--`` segments than the grammar allows must not be classified.
+    assert categorise_filename(Path("simgrid--vp--20180101--extra.roff")) is None
+
+
 # --------------------------------------------------------------------------- #
 # make_type_dict
 # --------------------------------------------------------------------------- #

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -1,0 +1,407 @@
+"""Tests for the post-run cleanup utilities in
+:mod:`fmu.pem.pem_utilities.cleanup`.
+
+The tests cover filename classification, the date-string detection, the strict
+resolution of FMU run/ensemble locations, and the end-to-end removal behaviour of
+:func:`cleanup_pem_results`.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from fmu.pem.pem_utilities.cleanup import (
+    _count_dates,
+    _find_run_grids_dir,
+    _is_grids_dir,
+    _normalise_remove_categories,
+    _resolve_remove_categories,
+    categorise_filename,
+    cleanup_pem_results,
+    crawl_ensemble,
+    make_type_dict,
+    remove_files,
+)
+from fmu.pem.pem_utilities.enum_defs import SaveTypes
+
+# A representative set of exported result files, grouped by expected category.
+GRID_FILES = ["simgrid.roff"]
+ELASTIC_FILES = [
+    "simgrid--vp--20180101.roff",
+    "simgrid--density--20180101.roff",
+]
+INTERMEDIATE_FILES = [
+    "simgrid--pressure--20180101.roff",
+    "simgrid--density_fluid--20180101.roff",
+    "simgrid--bulk_modulus_mineral.roff",
+]
+DIFFERENCE_FILES = ["simgrid--sidiffpercent--20180701_20180101.roff"]
+UNRELATED_FILES = ["notes.txt"]
+RESULT_FILES = GRID_FILES + ELASTIC_FILES + INTERMEDIATE_FILES + DIFFERENCE_FILES
+
+
+def _populate(grids_dir: Path) -> None:
+    """Create the representative result files (plus an unrelated file) in grids_dir."""
+    grids_dir.mkdir(parents=True, exist_ok=True)
+    for name in RESULT_FILES + UNRELATED_FILES:
+        (grids_dir / name).touch()
+
+
+def _make_ensemble(root: Path, n_real: int = 2) -> list[Path]:
+    """Build an ensemble tree below root and return the populated grids directories."""
+    grids_dirs = []
+    for realization in range(n_real):
+        grids_dir = (
+            root
+            / f"realization-{realization}"
+            / "iter-0"
+            / "share"
+            / "results"
+            / "grids"
+        )
+        _populate(grids_dir)
+        grids_dirs.append(grids_dir)
+    return grids_dirs
+
+
+def _names(grids_dir: Path) -> set[str]:
+    """Return the set of file names currently present in grids_dir."""
+    return {path.name for path in grids_dir.iterdir()}
+
+
+# --------------------------------------------------------------------------- #
+# _count_dates
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("", 0),
+        ("20180101", 1),
+        ("20180701_20180101", 2),
+        ("99999999", 0),  # eight digits, but not a valid calendar date
+        ("20181301", 0),  # month 13 is invalid
+        ("notadate", 0),
+    ],
+)
+def test_count_dates(text, expected):
+    assert _count_dates(text) == expected
+
+
+# --------------------------------------------------------------------------- #
+# categorise_filename
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "name, expected",
+    [
+        ("simgrid.roff", SaveTypes.GRID),
+        ("simgrid--vp--20180101.roff", SaveTypes.ELASTIC_PROPERTIES),
+        ("simgrid--vs--20180101.roff", SaveTypes.ELASTIC_PROPERTIES),
+        ("simgrid--density--20180101.roff", SaveTypes.ELASTIC_PROPERTIES),
+        ("simgrid--ai--20180101.roff", SaveTypes.ELASTIC_PROPERTIES),
+        ("simgrid--si--20180101.roff", SaveTypes.ELASTIC_PROPERTIES),
+        ("simgrid--vpvs--20180101.roff", SaveTypes.ELASTIC_PROPERTIES),
+        ("simgrid--pressure--20180101.roff", SaveTypes.INTERMEDIATE_PROPERTIES),
+        (
+            "simgrid--effective_pressure--20180101.roff",
+            SaveTypes.INTERMEDIATE_PROPERTIES,
+        ),
+        (
+            "simgrid--overburden_pressure--20180101.roff",
+            SaveTypes.INTERMEDIATE_PROPERTIES,
+        ),
+        ("simgrid--density_fluid--20180101.roff", SaveTypes.INTERMEDIATE_PROPERTIES),
+        ("simgrid--bulk_modulus_mineral.roff", SaveTypes.INTERMEDIATE_PROPERTIES),
+        ("simgrid--vp_dry_rock--20180101.roff", SaveTypes.INTERMEDIATE_PROPERTIES),
+        (
+            "simgrid--below_bubble_point--20180101.roff",
+            SaveTypes.INTERMEDIATE_PROPERTIES,
+        ),
+        (
+            "simgrid--sidiffpercent--20180701_20180101.roff",
+            SaveTypes.DIFFERENCE_PROPERTIES,
+        ),
+        ("simgrid--twtppdiff--20180701_20180101.roff", SaveTypes.DIFFERENCE_PROPERTIES),
+        ("simgrid--siratio--20180701_20180101.roff", SaveTypes.DIFFERENCE_PROPERTIES),
+    ],
+)
+def test_categorise_filename(name, expected):
+    assert categorise_filename(Path(name)) == expected
+
+
+def test_categorise_filename_invalid_date_returns_none():
+    # An eight-digit run that is not a real date is not treated as an elastic property.
+    assert categorise_filename(Path("simgrid--vp--20181301.roff")) is None
+
+
+# --------------------------------------------------------------------------- #
+# make_type_dict
+# --------------------------------------------------------------------------- #
+def test_make_type_dict_classifies_and_skips(tmp_path):
+    grids = tmp_path / "grids"
+    _populate(grids)
+    # An unrecognised file with a matching suffix/extension must be skipped.
+    (grids / "simgrid--vp--20181301.roff").touch()
+
+    type_dict = make_type_dict(grids)
+    by_name = {path.name: category for path, category in type_dict.items()}
+
+    assert by_name["simgrid.roff"] == SaveTypes.GRID
+    for name in ELASTIC_FILES:
+        assert by_name[name] == SaveTypes.ELASTIC_PROPERTIES
+    for name in INTERMEDIATE_FILES:
+        assert by_name[name] == SaveTypes.INTERMEDIATE_PROPERTIES
+    for name in DIFFERENCE_FILES:
+        assert by_name[name] == SaveTypes.DIFFERENCE_PROPERTIES
+    # Unrelated and unrecognised files are not present.
+    assert "notes.txt" not in by_name
+    assert "simgrid--vp--20181301.roff" not in by_name
+
+
+# --------------------------------------------------------------------------- #
+# remove_files
+# --------------------------------------------------------------------------- #
+def test_remove_files_unlinks(tmp_path):
+    files = [tmp_path / f"file_{i}.roff" for i in range(3)]
+    for file in files:
+        file.touch()
+
+    remove_files(files)
+
+    assert all(not file.exists() for file in files)
+
+
+def test_remove_files_missing_is_not_an_error(tmp_path):
+    remove_files([tmp_path / "absent.roff"])  # must not raise
+
+
+def test_remove_files_raises_when_deletion_fails(tmp_path):
+    # Unlinking a directory raises an OSError subclass, which must be reported.
+    a_directory = tmp_path / "a_directory"
+    a_directory.mkdir()
+    with pytest.raises(OSError):
+        remove_files([a_directory])
+
+
+# --------------------------------------------------------------------------- #
+# _is_grids_dir / _find_run_grids_dir / crawl_ensemble
+# --------------------------------------------------------------------------- #
+def test_is_grids_dir(tmp_path):
+    grids = tmp_path / "share" / "results" / "grids"
+    grids.mkdir(parents=True)
+    assert _is_grids_dir(grids)
+    assert not _is_grids_dir(tmp_path)
+
+
+def test_find_run_grids_dir_accepts_grids_dir(tmp_path):
+    grids = tmp_path / "share" / "results" / "grids"
+    grids.mkdir(parents=True)
+    assert _find_run_grids_dir(grids) == grids.resolve()
+
+
+def test_find_run_grids_dir_accepts_run_root(tmp_path):
+    grids = tmp_path / "share" / "results" / "grids"
+    grids.mkdir(parents=True)
+    # Pointing at the run root (one level above share/) resolves to the grids dir.
+    assert _find_run_grids_dir(tmp_path) == grids.resolve()
+
+
+def test_find_run_grids_dir_rejects_unrelated_location(tmp_path):
+    with pytest.raises(ValueError):
+        _find_run_grids_dir(tmp_path)
+
+
+def test_crawl_ensemble_yields_sorted_grids(tmp_path):
+    grids_dirs = _make_ensemble(tmp_path, n_real=3)
+    result = list(crawl_ensemble(tmp_path))
+    assert result == sorted(grids.resolve() for grids in grids_dirs)
+
+
+def test_crawl_ensemble_rejects_non_ensemble(tmp_path):
+    grids = tmp_path / "share" / "results" / "grids"
+    grids.mkdir(parents=True)  # a single run, not an ensemble top
+    with pytest.raises(ValueError):
+        list(crawl_ensemble(tmp_path))
+
+
+# --------------------------------------------------------------------------- #
+# _resolve_remove_categories
+# --------------------------------------------------------------------------- #
+def test_resolve_categories_all_includes_grid():
+    result = _resolve_remove_categories([SaveTypes.ALL])
+    assert result == {
+        SaveTypes.INTERMEDIATE_PROPERTIES,
+        SaveTypes.ELASTIC_PROPERTIES,
+        SaveTypes.DIFFERENCE_PROPERTIES,
+        SaveTypes.GRID,
+    }
+
+
+def test_resolve_categories_all_three_includes_grid():
+    result = _resolve_remove_categories(
+        [
+            SaveTypes.INTERMEDIATE_PROPERTIES,
+            SaveTypes.ELASTIC_PROPERTIES,
+            SaveTypes.DIFFERENCE_PROPERTIES,
+        ]
+    )
+    assert SaveTypes.GRID in result
+
+
+def test_resolve_categories_subset_excludes_grid():
+    result = _resolve_remove_categories([SaveTypes.ELASTIC_PROPERTIES])
+    assert result == {SaveTypes.ELASTIC_PROPERTIES}
+
+
+def test_resolve_categories_explicit_grid_dropped_without_all_three():
+    result = _resolve_remove_categories([SaveTypes.ELASTIC_PROPERTIES, SaveTypes.GRID])
+    assert result == {SaveTypes.ELASTIC_PROPERTIES}
+
+
+# --------------------------------------------------------------------------- #
+# _normalise_remove_categories
+# --------------------------------------------------------------------------- #
+def test_normalise_accepts_enum_members():
+    result = _normalise_remove_categories(
+        [SaveTypes.ELASTIC_PROPERTIES, SaveTypes.GRID]
+    )
+    assert result == [SaveTypes.ELASTIC_PROPERTIES, SaveTypes.GRID]
+
+
+def test_normalise_accepts_strings():
+    result = _normalise_remove_categories(["elastic", "all"])
+    assert result == [SaveTypes.ELASTIC_PROPERTIES, SaveTypes.ALL]
+
+
+def test_normalise_rejects_unknown_string():
+    with pytest.raises(ValueError):
+        _normalise_remove_categories(["elasctic"])
+
+
+# --------------------------------------------------------------------------- #
+# cleanup_pem_results - single run
+# --------------------------------------------------------------------------- #
+def test_cleanup_single_run_removes_only_requested(tmp_path):
+    grids = tmp_path / "share" / "results" / "grids"
+    _populate(grids)
+
+    cleanup_pem_results(grids, "simgrid", ".roff", [SaveTypes.INTERMEDIATE_PROPERTIES])
+
+    remaining = _names(grids)
+    assert all(name not in remaining for name in INTERMEDIATE_FILES)
+    kept = GRID_FILES + ELASTIC_FILES + DIFFERENCE_FILES + UNRELATED_FILES
+    assert all(name in remaining for name in kept)
+
+
+def test_cleanup_accepts_string_categories(tmp_path):
+    grids = tmp_path / "share" / "results" / "grids"
+    _populate(grids)
+
+    cleanup_pem_results(grids, "simgrid", ".roff", ["elastic"])
+
+    remaining = _names(grids)
+    assert all(name not in remaining for name in ELASTIC_FILES)
+    assert all(name in remaining for name in INTERMEDIATE_FILES)
+
+
+def test_cleanup_rejects_unknown_string_category(tmp_path):
+    grids = tmp_path / "share" / "results" / "grids"
+    _populate(grids)
+
+    with pytest.raises(ValueError):
+        cleanup_pem_results(grids, "simgrid", ".roff", ["elasctic"])
+
+
+def test_cleanup_single_run_via_run_root(tmp_path):
+    grids = tmp_path / "share" / "results" / "grids"
+    _populate(grids)
+
+    # Point at the run root rather than the grids directory.
+    cleanup_pem_results(tmp_path, "simgrid", ".roff", [SaveTypes.ELASTIC_PROPERTIES])
+
+    remaining = _names(grids)
+    assert all(name not in remaining for name in ELASTIC_FILES)
+    assert all(name in remaining for name in INTERMEDIATE_FILES)
+
+
+def test_cleanup_all_removes_every_result_but_keeps_unrelated(tmp_path):
+    grids = tmp_path / "share" / "results" / "grids"
+    _populate(grids)
+
+    cleanup_pem_results(grids, "simgrid", ".roff", [SaveTypes.ALL])
+
+    remaining = _names(grids)
+    assert all(name not in remaining for name in RESULT_FILES)
+    assert "notes.txt" in remaining
+
+
+def test_cleanup_keeps_grid_without_all_three_categories(tmp_path):
+    grids = tmp_path / "share" / "results" / "grids"
+    _populate(grids)
+
+    cleanup_pem_results(
+        grids,
+        "simgrid",
+        ".roff",
+        [SaveTypes.ELASTIC_PROPERTIES, SaveTypes.DIFFERENCE_PROPERTIES],
+    )
+
+    assert "simgrid.roff" in _names(grids)
+
+
+def test_cleanup_removes_grid_with_all_three_categories(tmp_path):
+    grids = tmp_path / "share" / "results" / "grids"
+    _populate(grids)
+
+    cleanup_pem_results(
+        grids,
+        "simgrid",
+        ".roff",
+        [
+            SaveTypes.INTERMEDIATE_PROPERTIES,
+            SaveTypes.ELASTIC_PROPERTIES,
+            SaveTypes.DIFFERENCE_PROPERTIES,
+        ],
+    )
+
+    assert "simgrid.roff" not in _names(grids)
+
+
+def test_cleanup_single_run_rejects_unrelated_location(tmp_path):
+    with pytest.raises(ValueError):
+        cleanup_pem_results(
+            tmp_path, "simgrid", ".roff", [SaveTypes.ELASTIC_PROPERTIES]
+        )
+
+
+# --------------------------------------------------------------------------- #
+# cleanup_pem_results - ensemble
+# --------------------------------------------------------------------------- #
+def test_cleanup_ensemble_processes_all_realizations(tmp_path):
+    grids_dirs = _make_ensemble(tmp_path, n_real=2)
+
+    cleanup_pem_results(
+        tmp_path,
+        "simgrid",
+        ".roff",
+        [SaveTypes.ELASTIC_PROPERTIES],
+        is_ensemble=True,
+    )
+
+    for grids in grids_dirs:
+        remaining = _names(grids)
+        assert all(name not in remaining for name in ELASTIC_FILES)
+        assert all(name in remaining for name in INTERMEDIATE_FILES)
+
+
+def test_cleanup_ensemble_rejects_single_run_location(tmp_path):
+    grids = tmp_path / "share" / "results" / "grids"
+    _populate(grids)
+
+    with pytest.raises(ValueError):
+        cleanup_pem_results(
+            tmp_path,
+            "simgrid",
+            ".roff",
+            [SaveTypes.ELASTIC_PROPERTIES],
+            is_ensemble=True,
+        )

--- a/tests/test_run_cleanup.py
+++ b/tests/test_run_cleanup.py
@@ -119,7 +119,7 @@ def test_pem_cleanup_forward_model_command():
     step = PemCleanup()
     assert step.name == "PEM_CLEANUP"
     assert step.executable == "pem_cleanup"
-    for flag in ("--grid_dir", "--save_type_list", "--is_ensemble", "--prefix"):
+    for flag in ("--grid_dir", "--save_type_list", "--prefix"):
         assert flag in step.arglist
 
 

--- a/tests/test_run_cleanup.py
+++ b/tests/test_run_cleanup.py
@@ -1,0 +1,138 @@
+"""Tests for the command-line and ERT forward-model entry points of pem_cleanup.
+
+The cleanup logic itself is covered in :mod:`tests.test_cleanup`; these tests
+exercise the wiring: the ``parse_cleanup`` argument parser, the ``run_pem_cleanup``
+console-script runner, and the ``PemCleanup`` ERT forward-model step.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from fmu.pem.pem_utilities.argument_parser import parse_cleanup
+from fmu.pem.run_cleanup import run_pem_cleanup
+
+GRID_FILE = "simgrid.roff"
+ELASTIC_FILES = ["simgrid--vp--20180101.roff", "simgrid--density--20180101.roff"]
+INTERMEDIATE_FILES = ["simgrid--pressure--20180101.roff"]
+DIFFERENCE_FILES = ["simgrid--sidiffpercent--20180701_20180101.roff"]
+RESULT_FILES = [GRID_FILE] + ELASTIC_FILES + INTERMEDIATE_FILES + DIFFERENCE_FILES
+
+
+def _populate(grids_dir: Path) -> None:
+    grids_dir.mkdir(parents=True, exist_ok=True)
+    for name in RESULT_FILES:
+        (grids_dir / name).touch()
+
+
+def _names(grids_dir: Path) -> set[str]:
+    return {path.name for path in grids_dir.iterdir()}
+
+
+# --------------------------------------------------------------------------- #
+# parse_cleanup
+# --------------------------------------------------------------------------- #
+def test_parse_cleanup_single_save_type_is_a_word():
+    args = parse_cleanup(["-g", "/tmp/grids", "-s", "elastic"])
+    assert args.save_type_list == ["elastic"]
+
+
+def test_parse_cleanup_multiple_save_types():
+    args = parse_cleanup(["-g", "/tmp/grids", "-s", "elastic", "intermediate"])
+    assert args.save_type_list == ["elastic", "intermediate"]
+
+
+def test_parse_cleanup_invalid_save_type_rejected():
+    with pytest.raises(SystemExit):
+        parse_cleanup(["-g", "/tmp/grids", "-s", "elasctic"])
+
+
+def test_parse_cleanup_defaults():
+    args = parse_cleanup(["-g", "/tmp/grids", "-s", "all"])
+    assert args.prefix == "simgrid"
+    assert args.extension == ".roff"
+    assert args.is_ensemble is False
+
+
+def test_parse_cleanup_is_ensemble_false_string():
+    args = parse_cleanup(["-g", "/tmp/grids", "-s", "all", "-i", "false"])
+    assert args.is_ensemble is False
+
+
+def test_parse_cleanup_is_ensemble_true_string():
+    args = parse_cleanup(["-g", "/tmp/grids", "-s", "all", "-i", "true"])
+    assert args.is_ensemble is True
+
+
+# --------------------------------------------------------------------------- #
+# run_pem_cleanup (CLI)
+# --------------------------------------------------------------------------- #
+def test_run_pem_cleanup_single_run(tmp_path):
+    grids = tmp_path / "share" / "results" / "grids"
+    _populate(grids)
+
+    run_pem_cleanup(["-g", str(grids), "-s", "elastic"])
+
+    remaining = _names(grids)
+    assert all(name not in remaining for name in ELASTIC_FILES)
+    assert all(name in remaining for name in INTERMEDIATE_FILES)
+    assert GRID_FILE in remaining
+
+
+def test_run_pem_cleanup_all(tmp_path):
+    grids = tmp_path / "share" / "results" / "grids"
+    _populate(grids)
+
+    run_pem_cleanup(["-g", str(grids), "-s", "all"])
+
+    assert _names(grids) == set()
+
+
+def test_run_pem_cleanup_ensemble(tmp_path):
+    grids_dirs = []
+    for realization in range(2):
+        grids = (
+            tmp_path
+            / f"realization-{realization}"
+            / "iter-0"
+            / "share"
+            / "results"
+            / "grids"
+        )
+        _populate(grids)
+        grids_dirs.append(grids)
+
+    run_pem_cleanup(["-g", str(tmp_path), "-s", "elastic", "-i", "true"])
+
+    for grids in grids_dirs:
+        remaining = _names(grids)
+        assert all(name not in remaining for name in ELASTIC_FILES)
+        assert all(name in remaining for name in INTERMEDIATE_FILES)
+
+
+# --------------------------------------------------------------------------- #
+# PemCleanup ERT forward-model step
+# --------------------------------------------------------------------------- #
+def test_pem_cleanup_forward_model_command():
+    from fmu.pem.forward_models import PemCleanup
+
+    step = PemCleanup()
+    assert step.name == "PEM_CLEANUP"
+    assert step.executable == "pem_cleanup"
+    for flag in ("--grid_dir", "--save_type_list", "--is_ensemble", "--prefix"):
+        assert flag in step.arglist
+
+
+def test_pem_cleanup_validate_hooks_pass():
+    from fmu.pem.forward_models import PemCleanup
+
+    step = PemCleanup()
+    assert step.validate_pre_realization_run({}) == {}
+    assert step.validate_pre_experiment({}) is None
+
+
+def test_pem_cleanup_registered_as_forward_model_step():
+    from fmu.pem.forward_models import PemCleanup
+    from fmu.pem.hook_implementations.jobs import installable_forward_model_steps
+
+    assert PemCleanup in installable_forward_model_steps().data


### PR DESCRIPTION
## Problem

After a PEM run — whether a single command-line run or a full ERT ensemble — the
`share/results/grids` directories accumulate intermediate/QC grids alongside the
final elastic and difference properties. There was no supported way to clean up
selected categories of result files afterwards.

## Solution

Add a `pem_cleanup` utility, exposed both as a console-script CLI and as an ERT
forward-model step (`PEM_CLEANUP`). It categorises exported grid files
(grid / intermediate / elastic / difference) by filename structure and removes
the requested categories from a single run or an entire ensemble, with strict
directory resolution so an unrelated parent can never be matched. The grid file
itself is only deleted when everything is removed (`all`, or all three property
categories explicitly).

Closes #106 

## Changes

- **feat(enum): add SaveTypes enum for result-file categories**
  Introduces `SaveTypes` (`intermediate`, `elastic`, `difference`, `grid`, `all`)
  as the shared vocabulary for cleanup categories.

- **feat(cleanup): add post-run PEM result cleanup utilities**
  New `cleanup.py`: filename categorisation via `--`-split structure and
  `datetime`-validated date strings (not just any 8 digits), strict resolution of
  single-run and ensemble grids directories, category normalisation that accepts
  plain strings and rejects unknown values, and `cleanup_pem_results` orchestration.

- **test(cleanup): add tests for cleanup utilities**
  Unit tests covering date counting, filename categorisation, type mapping, file
  removal, directory resolution, ensemble crawling, category resolution, and
  end-to-end single-run/ensemble cleanup.

- **feat: add cli entry point**
  `run_pem_cleanup` runner plus `parse_cleanup` argument parser; `pem_cleanup`
  console script. `-s/--save_type_list` uses `nargs="+"` with `choices` (single
  word or multiple words), and `-i/--is_ensemble` parses booleans correctly.

- **feat: add ERT forward model for pem_cleanup**
  `PemCleanup` `ForwardModelStepPlugin` (`PEM_CLEANUP`), registered in the ERT
  plugin hooks.

- **test: add CLI and ERT forward model tests**
  Tests for the argument parser, the `run_pem_cleanup` runner (single-run,
  `all`, ensemble), and the `PemCleanup` forward-model step (command, validation
  hooks, registration).