### PR TITLE
Fix/overburden pressure schema rendering

### DIFF
--- a/documentation/docs/yaml-edit/YamlEdit.tsx
+++ b/documentation/docs/yaml-edit/YamlEdit.tsx
@@ -34,6 +34,8 @@ function TitleFieldTemplate({ id, title, required }: Pick<TitleFieldProps, "id" 
     <div
       id={id}
       className="rjsf-field-title"
+      role="heading"
+      aria-level={3}
       style={{
         fontSize: "1.15rem",
         fontWeight: 700,

--- a/documentation/docs/yaml-edit/YamlEdit.tsx
+++ b/documentation/docs/yaml-edit/YamlEdit.tsx
@@ -16,13 +16,37 @@ import {
 
 import { copy } from "@equinor/eds-icons";
 
-import { TranslatableString, englishStringTranslator, replaceStringParameters } from '@rjsf/utils';
+import { TranslatableString, englishStringTranslator, replaceStringParameters, type TitleFieldProps } from '@rjsf/utils';
 
 function customStrings(stringToTranslate: TranslatableString, params?: string[]): string {
   if(stringToTranslate === TranslatableString.KeyLabel) {
     return replaceStringParameters('Key:', params);
   }
   return englishStringTranslator(stringToTranslate, params);
+}
+
+// VitePress flattens RJSF's default field titles, so render them as explicit headings.
+function TitleFieldTemplate({ id, title, required }: TitleFieldProps) {
+  if (!title) {
+    return null;
+  }
+  return (
+    <div
+      id={id}
+      className="rjsf-field-title"
+      style={{
+        fontSize: "1.15rem",
+        fontWeight: 700,
+        marginTop: "1.5rem",
+        marginBottom: "0.5rem",
+        paddingBottom: "0.25rem",
+        borderBottom: "1px solid var(--vp-c-divider, #e2e2e3)",
+      }}
+    >
+      {title}
+      {required ? " *" : null}
+    </div>
+  );
 }
 
 export const YamlEdit = () => {
@@ -168,6 +192,7 @@ export const YamlEdit = () => {
             liveValidate
             omitExtraData
             liveOmit
+            templates={{ TitleFieldTemplate }}
             uiSchema={{
               "ui:submitButtonOptions": { norender: true },
               "ui:globalOptions": {

--- a/documentation/docs/yaml-edit/YamlEdit.tsx
+++ b/documentation/docs/yaml-edit/YamlEdit.tsx
@@ -16,7 +16,7 @@ import {
 
 import { copy } from "@equinor/eds-icons";
 
-import { TranslatableString, englishStringTranslator, replaceStringParameters, type TitleFieldProps } from '@rjsf/utils';
+import { TranslatableString, englishStringTranslator, replaceStringParameters, getUiOptions, type TitleFieldProps, type ArrayFieldTemplateProps } from '@rjsf/utils';
 
 function customStrings(stringToTranslate: TranslatableString, params?: string[]): string {
   if(stringToTranslate === TranslatableString.KeyLabel) {
@@ -26,7 +26,7 @@ function customStrings(stringToTranslate: TranslatableString, params?: string[])
 }
 
 // VitePress flattens RJSF's default field titles, so render them as explicit headings.
-function TitleFieldTemplate({ id, title, required }: TitleFieldProps) {
+function TitleFieldTemplate({ id, title, required }: Pick<TitleFieldProps, "id" | "title" | "required">) {
   if (!title) {
     return null;
   }
@@ -46,6 +46,70 @@ function TitleFieldTemplate({ id, title, required }: TitleFieldProps) {
       {title}
       {required ? " *" : null}
     </div>
+  );
+}
+
+// Arrays whose items are a discriminated `oneOf` (e.g. `pressure`) do not render
+// their array-level title until the first item is added, unlike arrays of a
+// single `$ref` (e.g. `zone_regions`). Give such arrays a template that always
+// renders the title heading up front, matching the `zone_regions` appearance.
+function TitledArrayFieldTemplate(props: ArrayFieldTemplateProps) {
+  const {
+    canAdd,
+    className,
+    disabled,
+    fieldPathId,
+    uiSchema,
+    items,
+    onAddClick,
+    readonly,
+    registry,
+    required,
+    schema,
+    title,
+  } = props;
+  const uiOptions = getUiOptions(uiSchema);
+  const displayTitle = uiOptions.title || title;
+  const description = uiOptions.description || schema.description;
+  const {
+    ButtonTemplates: { AddButton },
+  } = registry.templates;
+  const baseId = fieldPathId?.$id ?? "array";
+  return (
+    <fieldset className={className} id={fieldPathId?.$id}>
+      {displayTitle ? (
+        <TitleFieldTemplate
+          id={`${baseId}__title`}
+          title={displayTitle}
+          required={required}
+        />
+      ) : null}
+      {description ? (
+        <p className="field-description" style={{ marginBottom: "0.5rem" }}>
+          {description}
+        </p>
+      ) : null}
+      <div className="row array-item-list">
+        {items &&
+          items.map((element: any, index: number) =>
+            React.isValidElement(element) ? (
+              element
+            ) : (
+              <div key={element?.key ?? index}>{element?.children}</div>
+            ),
+          )}
+      </div>
+      {canAdd ? (
+        <AddButton
+          id={`${baseId}__add`}
+          className="rjsf-array-item-add"
+          onClick={onAddClick}
+          disabled={disabled || readonly}
+          uiSchema={uiSchema}
+          registry={registry}
+        />
+      ) : null}
+    </fieldset>
   );
 }
 
@@ -226,6 +290,11 @@ export const YamlEdit = () => {
                     },
                   },
                 },
+              },
+              // The pressure array items are a discriminated `oneOf`; use a
+              // template that always renders the array title heading up front.
+              pressure: {
+                "ui:ArrayFieldTemplate": TitledArrayFieldTemplate,
               },
             }}
             showErrorList={false}

--- a/src/fmu/pem/pem_utilities/pem_config_validation.py
+++ b/src/fmu/pem/pem_utilities/pem_config_validation.py
@@ -1,7 +1,7 @@
 import os
 from datetime import date
 from pathlib import Path
-from typing import Any, Literal, Self
+from typing import Annotated, Any, Literal, Self
 
 import numpy as np
 from pydantic import (
@@ -410,7 +410,11 @@ class RockMatrixProperties(BaseModel):
 
 # Pressure
 class OverburdenPressureTrend(BaseModel):
-    type: SkipJsonSchema[OverburdenPressureTypes] = OverburdenPressureTypes.TREND
+    model_config = ConfigDict(title="Overburden pressure from depth trend")
+
+    type: SkipJsonSchema[Literal[OverburdenPressureTypes.TREND]] = (
+        OverburdenPressureTypes.TREND
+    )
     fipnum: str = Field(
         default="*",
         description="Each grid cell in a reservoir model is assigned a FIPNUM "
@@ -426,7 +430,11 @@ class OverburdenPressureTrend(BaseModel):
 
 
 class OverburdenPressureConstant(BaseModel):
-    type: SkipJsonSchema[OverburdenPressureTypes] = OverburdenPressureTypes.CONSTANT
+    model_config = ConfigDict(title="Constant overburden pressure")
+
+    type: SkipJsonSchema[Literal[OverburdenPressureTypes.CONSTANT]] = (
+        OverburdenPressureTypes.CONSTANT
+    )
     fipnum: str = Field(
         default="*",
         description="Each grid cell in a reservoir model is assigned a FIPNUM "
@@ -791,9 +799,16 @@ class PemConfig(BaseModel):
         "calculation of effective fluid properties. You can have multiple fluid PVT "
         "definitions, representing e.g. different regions and/or zones in your model.",
     )
-    pressure: list[OverburdenPressureTrend | OverburdenPressureConstant] = Field(
-        default_factory=OverburdenPressureTrend,
-        description="Definition of overburden pressure model - constant or trend",
+    pressure: list[
+        Annotated[
+            OverburdenPressureTrend | OverburdenPressureConstant,
+            Field(discriminator="type"),
+        ]
+    ] = Field(
+        title="Overburden pressure",
+        description="Definition of overburden pressure model - constant or trend. "
+        "One entry per FIPNUM group; the FIPNUM grouping is independent of the "
+        "rock-matrix and pressure-sensitivity grouping.",
     )
     results: Results = Field(
         description="Flags for saving results of the PEM",


### PR DESCRIPTION
```markdown
## Problem

In the JSON-schema-driven config editor (docs `YamlEdit`), the **overburden pressure** section no longer offered its trend/constant variant selector, and its section heading was missing.

Two separate causes:

1. **No variant selector.** `PemConfig.pressure` was a plain union
   (`list[OverburdenPressureTrend | OverburdenPressureConstant]`) whose
   `type` discriminator was hidden via `SkipJsonSchema`. Without a
   discriminator in the schema, RJSF emitted a bare `anyOf` and could not
   render a per-item selector. The field also used a broken
   `default_factory=OverburdenPressureTrend`, which returns a single model
   instead of a list.

2. **No section heading.** Arrays whose items are a discriminated `oneOf`
   (like `pressure`) do not render their array-level title until the first
   item is added, unlike arrays of a single `$ref` (like `zone_regions`).
   Users only saw the description text, with no heading.

## Solution

- Turn `pressure` into a proper **discriminated union** (`Field(discriminator="type")`
  with `Literal` type values), so the generated schema emits
  `discriminator` + `oneOf` + `mapping` and RJSF renders the variant
  selector. Per-FIPNUM grouping for pressure is preserved and remains
  independent of the rock-matrix / pressure-sensitivity grouping.
- Give the union members friendly `title`s so the dropdown reads
  "Overburden pressure from depth trend" / "Constant overburden pressure".
- Add a scoped `ArrayFieldTemplate` for the `pressure` field that always
  renders the array-level title heading up front, matching the
  `zone_regions` appearance. No schema restructuring, so the existing YAML
  config format is unchanged.

**Note:** removing the (broken) `default_factory` makes `pressure` a
required field. All existing configs already specify `pressure`, so this
only tightens validation.

## Changes

### `fix(validation): render overburden pressure per-FIPNUM groups in JSON schema`
- `OverburdenPressureTrend` / `OverburdenPressureConstant`: pin `type` to a
  `Literal[...]` and add `ConfigDict(title=...)` friendly titles.
- `PemConfig.pressure`: annotate the list item union with
  `Field(discriminator="type")`, add an "Overburden pressure" title and a
  clarified description; remove the invalid `default_factory`.

### `fix(docs): always render overburden pressure array title heading`
- `YamlEdit.tsx`: add `TitledArrayFieldTemplate` and register it for the
  `pressure` field via `ui:ArrayFieldTemplate`, so the section heading shows
  before any item is added. Preserves item toolbars and the Add button.
```