### PR TITLE
Ci/python versions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -36,7 +36,7 @@ tests/
 - **Python ≥ 3.11** is required; use modern type annotations (`X | Y`,
   `list[X]`, `tuple[X, Y]`).
 - All source files must be compatible with the Python versions tested in CI
-  (`3.11`, `3.12`).
+  (`3.11`, `3.12`, `3.13`, `3.14`).
 
 ---
 

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3,13", "3.14"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12", "3,13", "3.14"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
     "Topic :: Utilities",
     "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
     "Operating System :: POSIX :: Linux",
@@ -31,17 +31,15 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "numpy >= 1.24.3",
-    "xtgeo >= 4.7.1",
-    "resfo",
-    "fmu-tools",
+    "ert >= 23.0.0",
     "fmu-config",
-    "fmu-dataio",
-    "fmu-datamodels",
-    "rock-physics-open >= 1.0.0",
-    "PyYAML >=6.0.1",
+    "fmu-tools",
+    "numpy >= 2.4.6",
     "pydantic",
-    "ert >= 14.1.10",
+    "PyYAML >=6.0.3",
+    "resfo",
+    "rock-physics-open >= 1.0.1",
+    "xtgeo >= 4.24.5",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,13 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Physics",
     "Topic :: Software Development :: Libraries",
     "Topic :: Utilities",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Operating System :: POSIX :: Linux",
     "Natural Language :: English",
+    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
 ]
 dynamic = ["version"]
 dependencies = [


### PR DESCRIPTION
## Purpose

Update python versions that are supported in this repository and revisit dependencies.

## Details

Python 3.11 is only kept for consistency with other repos, as 3.12 is now the default version in `komodo`. Legacy modules in the FMU family are revisited, and those that are no longer required by `fmu-pem` are removed. 

## Testing
- ruff format: pass
- ruff check: pass
- pytest: all tests pass